### PR TITLE
Add ShadCN sidebar navigation

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,85 +1,35 @@
-import "./App.css";
-import { BrowserRouter as Router, Routes, Route, Link } from "react-router-dom";
-import ActiveFlights from "./ActiveFlights";
-import UiElements from "./UiElements";
-
-interface AcarsMessage {
-  id: number;
-  time: string;
-  sender: string;
-  message: string;
-}
-
-const dummyData: AcarsMessage[] = [
-  {
-    id: 1,
-    time: "12:00Z",
-    sender: "ATC",
-    message: "CLEARED FL350"
-  },
-  {
-    id: 2,
-    time: "12:05Z",
-    sender: "DISP",
-    message: "WEATHER UPDATE"
-  },
-  {
-    id: 3,
-    time: "12:10Z",
-    sender: "ATC",
-    message: "CONTACT CENTER"
-  }
-];
-
-function Home() {
-  return (
-    <div className="App">
-      <h1>Electron ACARS Viewer</h1>
-      <table>
-        <thead>
-          <tr>
-            <th>Time</th>
-            <th>Sender</th>
-            <th>Message</th>
-          </tr>
-        </thead>
-        <tbody>
-          {dummyData.map((item) => (
-            <tr key={item.id}>
-              <td>{item.time}</td>
-              <td>{item.sender}</td>
-              <td>{item.message}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  );
-}
+import './App.css'
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
+import ActiveFlights from './ActiveFlights'
+import UiElements from './UiElements'
+import Dashboard from './pages/Dashboard'
+import LiveFlight from './pages/LiveFlight'
+import Logbook from './pages/Logbook'
+import Fleet from './pages/Fleet'
+import VirtualAirline from './pages/VirtualAirline'
+import Settings from './pages/Settings'
+import { Sidebar } from './components'
 
 function App() {
   return (
     <Router>
-      <nav>
-        <ul>
-          <li>
-            <Link to="/">Home</Link>
-          </li>
-          <li>
-            <Link to="/active-flights">Active Flights</Link>
-          </li>
-          <li>
-            <Link to="/elements">UI Elements</Link>
-          </li>
-        </ul>
-      </nav>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/active-flights" element={<ActiveFlights />} />
-        <Route path="/elements" element={<UiElements />} />
-      </Routes>
+      <div className="flex h-screen">
+        <Sidebar />
+        <div className="flex-1 overflow-auto p-4">
+          <Routes>
+            <Route path="/" element={<Dashboard />} />
+            <Route path="/live-flight" element={<LiveFlight />} />
+            <Route path="/logbook" element={<Logbook />} />
+            <Route path="/fleet" element={<Fleet />} />
+            <Route path="/virtual-airline" element={<VirtualAirline />} />
+            <Route path="/settings" element={<Settings />} />
+            <Route path="/active-flights" element={<ActiveFlights />} />
+            <Route path="/elements" element={<UiElements />} />
+          </Routes>
+        </div>
+      </div>
     </Router>
-  );
+  )
 }
 
 export default App;

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -1,0 +1,50 @@
+import { NavLink } from 'react-router-dom'
+import {
+  LayoutDashboard,
+  Plane,
+  BookOpen,
+  PlaneTakeoff,
+  Building2,
+  Settings as SettingsIcon,
+} from 'lucide-react'
+import { cn } from './utils'
+
+interface Item {
+  to: string
+  label: string
+  icon: React.ComponentType<{ className?: string }>
+}
+
+const items: Item[] = [
+  { to: '/', label: 'Dashboard', icon: LayoutDashboard },
+  { to: '/live-flight', label: 'Live Flight', icon: Plane },
+  { to: '/logbook', label: 'Logbook', icon: BookOpen },
+  { to: '/fleet', label: 'Fleet', icon: PlaneTakeoff },
+  { to: '/virtual-airline', label: 'Virtual Airline', icon: Building2 },
+  { to: '/settings', label: 'Settings', icon: SettingsIcon },
+]
+
+export function Sidebar() {
+  return (
+    <nav className="w-48 space-y-1 bg-gray-100 p-4">
+      {items.map(({ to, label, icon: Icon }) => (
+        <NavLink
+          key={to}
+          to={to}
+          end={to === '/'}
+          className={({ isActive }) =>
+            cn(
+              'flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium',
+              isActive
+                ? 'bg-blue-600 text-white'
+                : 'text-gray-700 hover:bg-gray-200'
+            )
+          }
+        >
+          <Icon className="h-4 w-4" />
+          {label}
+        </NavLink>
+      ))}
+    </nav>
+  )
+}

--- a/app/src/components/index.ts
+++ b/app/src/components/index.ts
@@ -1,3 +1,4 @@
 export * from './DataTable'
 export * from './ui'
 export * from './maps'
+export * from './Sidebar'

--- a/app/src/pages/Dashboard.tsx
+++ b/app/src/pages/Dashboard.tsx
@@ -1,0 +1,7 @@
+export default function Dashboard() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">Dashboard</h1>
+    </div>
+  )
+}

--- a/app/src/pages/Fleet.tsx
+++ b/app/src/pages/Fleet.tsx
@@ -1,0 +1,7 @@
+export default function Fleet() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">Fleet</h1>
+    </div>
+  )
+}

--- a/app/src/pages/LiveFlight.tsx
+++ b/app/src/pages/LiveFlight.tsx
@@ -1,0 +1,7 @@
+export default function LiveFlight() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">Live Flight</h1>
+    </div>
+  )
+}

--- a/app/src/pages/Logbook.tsx
+++ b/app/src/pages/Logbook.tsx
@@ -1,0 +1,7 @@
+export default function Logbook() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">Logbook</h1>
+    </div>
+  )
+}

--- a/app/src/pages/Settings.tsx
+++ b/app/src/pages/Settings.tsx
@@ -1,0 +1,7 @@
+export default function Settings() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">Settings</h1>
+    </div>
+  )
+}

--- a/app/src/pages/VirtualAirline.tsx
+++ b/app/src/pages/VirtualAirline.tsx
@@ -1,0 +1,7 @@
+export default function VirtualAirline() {
+  return (
+    <div className="p-4">
+      <h1 className="text-2xl font-bold">Virtual Airline</h1>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- create simple pages for Dashboard, LiveFlight, Logbook, Fleet, Virtual Airline and Settings
- add `Sidebar` component using ShadCN styles and `NavLink`
- integrate sidebar layout and routes into `App`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68578a80d1cc8322a4c5755e132861f6