### PR TITLE
Add Community Hub screen and sidebar

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -2,6 +2,9 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=Noto+Sans:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + React + TS</title>

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -23,6 +23,8 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.25.0",
+        "@tailwindcss/container-queries": "^0.1.1",
+        "@tailwindcss/forms": "^0.5.10",
         "@types/leaflet": "^1.9.18",
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
@@ -1491,6 +1493,29 @@
       },
       "bin": {
         "ui": "dist/index.js"
+      }
+    },
+    "node_modules/@tailwindcss/container-queries": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/container-queries/-/container-queries-0.1.1.tgz",
+      "integrity": "sha512-p18dswChx6WnTSaJCSGx6lTmrGzNNvm2FtXmiO6AuA1V4U5REyoqwmT6kgAsIMdjo07QdAfYXHJ4hnMtfHzWgA==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "tailwindcss": ">=3.2.0"
+      }
+    },
+    "node_modules/@tailwindcss/forms": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/forms/-/forms-0.5.10.tgz",
+      "integrity": "sha512-utI1ONF6uf/pPNO68kmN1b8rEwNXv3czukalo8VtJH8ksIkZXr3Q3VYudZLkCsDd4Wku120uF02hYK25XGPorw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mini-svg-data-uri": "^1.2.3"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
       }
     },
     "node_modules/@types/babel__core": {
@@ -3558,6 +3583,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mini-svg-data-uri": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/mini-svg-data-uri/-/mini-svg-data-uri-1.4.4.tgz",
+      "integrity": "sha512-r9deDe9p5FJUPZAk3A59wGH7Ii9YrjjWw0jmw/liSbHl2CHiyXj6FcDXDu2K3TjVAXqiJdaw3xxwlZZr9E6nHg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mini-svg-data-uri": "cli.js"
       }
     },
     "node_modules/minimatch": {

--- a/app/package.json
+++ b/app/package.json
@@ -37,6 +37,8 @@
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.4",
     "tailwindcss-animate": "^1.0.7",
+    "@tailwindcss/forms": "^0.5.10",
+    "@tailwindcss/container-queries": "^0.1.1",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.30.1",
     "vite": "^6.3.5"

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,85 +1,31 @@
-import "./App.css";
-import { BrowserRouter as Router, Routes, Route, Link } from "react-router-dom";
-import ActiveFlights from "./ActiveFlights";
-import UiElements from "./UiElements";
+import { BrowserRouter as Router, Routes, Route } from 'react-router-dom'
+import { useState } from 'react'
+import Sidebar from './components/Sidebar'
+import CommunityHub from './components/CommunityHub'
+import ActiveFlights from './ActiveFlights'
+import UiElements from './UiElements'
 
-interface AcarsMessage {
-  id: number;
-  time: string;
-  sender: string;
-  message: string;
+function Placeholder({ title }: { title: string }) {
+  return <div className="p-6 text-white">{title}</div>
 }
 
-const dummyData: AcarsMessage[] = [
-  {
-    id: 1,
-    time: "12:00Z",
-    sender: "ATC",
-    message: "CLEARED FL350"
-  },
-  {
-    id: 2,
-    time: "12:05Z",
-    sender: "DISP",
-    message: "WEATHER UPDATE"
-  },
-  {
-    id: 3,
-    time: "12:10Z",
-    sender: "ATC",
-    message: "CONTACT CENTER"
-  }
-];
+export default function App() {
+  const [open, setOpen] = useState(false)
 
-function Home() {
-  return (
-    <div className="App">
-      <h1>Electron ACARS Viewer</h1>
-      <table>
-        <thead>
-          <tr>
-            <th>Time</th>
-            <th>Sender</th>
-            <th>Message</th>
-          </tr>
-        </thead>
-        <tbody>
-          {dummyData.map((item) => (
-            <tr key={item.id}>
-              <td>{item.time}</td>
-              <td>{item.sender}</td>
-              <td>{item.message}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
-    </div>
-  );
-}
-
-function App() {
   return (
     <Router>
-      <nav>
-        <ul>
-          <li>
-            <Link to="/">Home</Link>
-          </li>
-          <li>
-            <Link to="/active-flights">Active Flights</Link>
-          </li>
-          <li>
-            <Link to="/elements">UI Elements</Link>
-          </li>
-        </ul>
-      </nav>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/active-flights" element={<ActiveFlights />} />
-        <Route path="/elements" element={<UiElements />} />
-      </Routes>
+      <Sidebar open={open} onToggle={setOpen} />
+      <div className={`ml-16 transition-all lg:ml-80 ${open ? 'ml-80' : 'ml-16'}`}> 
+        <Routes>
+          <Route path="/" element={<Placeholder title="Home" />} />
+          <Route path="/flights" element={<ActiveFlights />} />
+          <Route path="/community" element={<CommunityHub />} />
+          <Route path="/roster" element={<Placeholder title="Roster" />} />
+          <Route path="/settings" element={<Placeholder title="Settings" />} />
+          <Route path="/elements" element={<UiElements />} />
+          <Route path="/admin" element={<Placeholder title="Admin" />} />
+        </Routes>
+      </div>
     </Router>
-  );
+  )
 }
-
-export default App;

--- a/app/src/components/CommunityHub.tsx
+++ b/app/src/components/CommunityHub.tsx
@@ -1,0 +1,61 @@
+import { Calendar } from 'lucide-react'
+
+export default function CommunityHub() {
+  const activities = [
+    { id: 1, pilot: 'John Doe', flight: 'VA123', avatar: 'https://via.placeholder.com/56' },
+    { id: 2, pilot: 'Jane Smith', flight: 'VA456', avatar: 'https://via.placeholder.com/56' },
+  ]
+
+  const events = [
+    { id: 1, name: 'Group Flight', date: 'June 12, 2024' },
+    { id: 2, name: 'Training Session', date: 'July 5, 2024' },
+  ]
+
+  return (
+    <div className="space-y-8 p-6 text-white">
+      <header className="space-y-1">
+        <h1 className="font-heading text-3xl">Community Hub</h1>
+        <p className="font-body text-[#90adcb]">Latest airline activity and events</p>
+      </header>
+
+      <section className="space-y-4">
+        <h2 className="font-heading text-2xl">Active Flights</h2>
+        <div className="aspect-video w-full overflow-hidden rounded-lg bg-[#223649]">
+          <img src="https://via.placeholder.com/800x450" alt="Map" className="h-full w-full object-cover" />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="font-heading text-2xl">Recent Activity</h2>
+        <div className="space-y-2">
+          {activities.map(act => (
+            <div key={act.id} className="flex h-18 items-center gap-4 rounded-lg bg-[#101a23] p-4">
+              <img src={act.avatar} alt="avatar" className="h-14 w-14 rounded-full object-cover" />
+              <div className="flex flex-col">
+                <span className="font-medium">Pilot: {act.pilot}</span>
+                <span className="text-sm text-[#90adcb]">Flight: {act.flight}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="font-heading text-2xl">Upcoming Events</h2>
+        <div className="space-y-2">
+          {events.map(ev => (
+            <div key={ev.id} className="flex h-18 items-center gap-4 rounded-lg bg-[#101a23] p-4">
+              <div className="flex h-12 w-12 items-center justify-center rounded-full bg-[#223649]">
+                <Calendar className="h-6 w-6" />
+              </div>
+              <div className="flex flex-col">
+                <span className="font-medium">{ev.name}</span>
+                <span className="text-sm text-[#90adcb]">{ev.date}</span>
+              </div>
+            </div>
+          ))}
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -1,0 +1,80 @@
+import { NavLink } from 'react-router-dom'
+import { Home, Plane, Users, Calendar, Settings, Shield, Menu } from 'lucide-react'
+import { useState } from 'react'
+
+interface SidebarProps {
+  open?: boolean
+  onToggle?: (open: boolean) => void
+}
+
+export default function Sidebar({ open = false, onToggle }: SidebarProps) {
+  const [internalOpen, setInternalOpen] = useState(false)
+  const isControlled = onToggle !== undefined
+  const isOpen = isControlled ? open : internalOpen
+
+  const toggle = () => {
+    if (isControlled) onToggle?.(!open)
+    else setInternalOpen(!internalOpen)
+  }
+
+  const items = [
+    { to: '/', label: 'Home', icon: Home },
+    { to: '/flights', label: 'Flights', icon: Plane },
+    { to: '/community', label: 'Community', icon: Users },
+    { to: '/roster', label: 'Roster', icon: Calendar },
+    { to: '/settings', label: 'Settings', icon: Settings },
+  ]
+
+  const admin = { to: '/admin', label: 'Admin', icon: Shield }
+
+  const AdminIcon = admin.icon
+  
+  return (
+    <aside
+      className={`fixed left-0 top-0 z-20 h-full bg-[#101a23] transition-all lg:w-80 ${
+        isOpen ? 'w-80' : 'w-16'
+      }`}
+    >
+      <div className="flex h-full flex-col">
+        <div className="flex items-center justify-between p-4 text-white">
+          <span className="flex items-center gap-2">
+            <Plane className="h-6 w-6" />
+            <span className={`${isOpen ? 'block' : 'hidden lg:block'} font-heading text-xl`}>VA Stats</span>
+          </span>
+          <button className="lg:hidden" onClick={toggle}>
+            <Menu className="h-6 w-6" />
+          </button>
+        </div>
+        <nav className="flex-1 space-y-1 px-2">
+          {items.map(({ to, label, icon: Icon }) => (
+            <NavLink
+              key={to}
+              to={to}
+              className={({ isActive }) =>
+                `flex items-center gap-3 rounded-md p-2 text-white hover:bg-[#223649] ${
+                  isActive ? 'bg-[#223649]' : ''
+                }`
+              }
+            >
+              <Icon className="h-5 w-5" />
+              <span className={`${isOpen ? 'block' : 'hidden lg:block'}`}>{label}</span>
+            </NavLink>
+          ))}
+        </nav>
+        <div className="mt-auto px-2 pb-4">
+          <NavLink
+            to={admin.to}
+            className={({ isActive }) =>
+              `flex items-center gap-3 rounded-md p-2 text-white hover:bg-[#223649] ${
+                isActive ? 'bg-[#223649]' : ''
+              }`
+            }
+          >
+            <AdminIcon className="h-5 w-5" />
+            <span className={`${isOpen ? 'block' : 'hidden lg:block'}`}>{admin.label}</span>
+          </NavLink>
+        </div>
+      </div>
+    </aside>
+  )
+}

--- a/app/tailwind.config.ts
+++ b/app/tailwind.config.ts
@@ -1,5 +1,7 @@
 import type { Config } from 'tailwindcss'
 import animate from 'tailwindcss-animate'
+import forms from '@tailwindcss/forms'
+import containerQueries from '@tailwindcss/container-queries'
 
 export default {
   darkMode: 'class',
@@ -8,7 +10,12 @@ export default {
     './src/**/*.{ts,tsx}',
   ],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        heading: ['"Space Grotesk"', 'sans-serif'],
+        body: ['"Noto Sans"', 'sans-serif'],
+      },
+    },
   },
-  plugins: [animate],
+  plugins: [animate, forms, containerQueries],
 } satisfies Config


### PR DESCRIPTION
## Summary
- add Tailwind container-queries and forms plugins
- include Google fonts for Space Grotesk and Noto Sans
- implement responsive Sidebar component
- create CommunityHub screen with sections
- wire components together via router

## Testing
- `npm --prefix app run build`
- `npm test` *(fails: spawn xvfb-run ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68585421ac6483228f7b8a1dc5142b99