### PR TITLE
Add login screen component

### DIFF
--- a/app/src/AuthContext.tsx
+++ b/app/src/AuthContext.tsx
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react'
+
+interface AuthContextValue {
+  login: () => void
+}
+
+const AuthContext = createContext<AuthContextValue>({
+  login: () => {},
+})
+
+export function useAuth() {
+  return useContext(AuthContext)
+}
+
+export default AuthContext

--- a/app/src/LoginScreen.tsx
+++ b/app/src/LoginScreen.tsx
@@ -1,0 +1,55 @@
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Button, Input, Label } from './components'
+import { useAuth } from './AuthContext'
+
+export function LoginScreen() {
+  const [username, setUsername] = useState('')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const auth = useAuth()
+  const navigate = useNavigate()
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (username === 'user' && password === 'pass') {
+      auth.login()
+      navigate('/dashboard')
+    } else {
+      setError('Invalid username or password')
+    }
+  }
+
+  return (
+    <div className="flex h-screen items-center justify-center bg-gray-100">
+      <form
+        onSubmit={handleSubmit}
+        className="w-full max-w-sm space-y-4 rounded-md bg-white p-6 shadow"
+      >
+        <div className="space-y-1">
+          <Label htmlFor="username">Username</Label>
+          <Input
+            id="username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+          />
+        </div>
+        <div className="space-y-1">
+          <Label htmlFor="password">Password</Label>
+          <Input
+            id="password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+          />
+        </div>
+        {error && <p className="text-sm text-red-500">{error}</p>}
+        <Button type="submit" className="w-full">
+          Sign In
+        </Button>
+      </form>
+    </div>
+  )
+}
+
+export default LoginScreen


### PR DESCRIPTION
## Summary
- stub out an `AuthContext` with `useAuth`
- add `LoginScreen` component for authentication

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858582b41b08322b826dd541491ff81