### PR TITLE
Add ProfilePage with logout functionality

### DIFF
--- a/app/src/ProfilePage.tsx
+++ b/app/src/ProfilePage.tsx
@@ -1,0 +1,35 @@
+import { useNavigate } from 'react-router-dom'
+import { Button } from './components'
+import { useAuth } from './authSlice'
+
+export function ProfilePage() {
+  const auth = useAuth()
+  const navigate = useNavigate()
+  const user = auth.user ?? { username: 'user', email: 'user@example.com' }
+
+  const handleLogout = () => {
+    auth.logout()
+    navigate('/login')
+  }
+
+  return (
+    <div className="flex h-screen items-center justify-center bg-gray-900">
+      <div className="w-full max-w-sm space-y-4 rounded-lg bg-[#101a23] p-6 text-white">
+        <img
+          src={`https://ui-avatars.com/api/?name=${user.username}`}
+          alt="avatar"
+          className="mx-auto h-24 w-24 rounded-full"
+        />
+        <div className="space-y-1 text-center">
+          <h2 className="text-xl font-semibold">{user.username}</h2>
+          <p className="text-gray-300">{user.email}</p>
+        </div>
+        <Button className="w-full" onClick={handleLogout}>
+          Log Out
+        </Button>
+      </div>
+    </div>
+  )
+}
+
+export default ProfilePage

--- a/app/src/authSlice.ts
+++ b/app/src/authSlice.ts
@@ -4,10 +4,15 @@ import type { RootState } from './store'
 
 export interface AuthState {
   isAuthenticated: boolean
+  user: {
+    username: string
+    email: string
+  } | null
 }
 
 const initialState: AuthState = {
   isAuthenticated: false,
+  user: null,
 }
 
 const authSlice = createSlice({
@@ -16,9 +21,11 @@ const authSlice = createSlice({
   reducers: {
     login(state) {
       state.isAuthenticated = true
+      state.user = { username: 'user', email: 'user@example.com' }
     },
     logout(state) {
       state.isAuthenticated = false
+      state.user = null
     },
   },
 })
@@ -28,12 +35,15 @@ export default authSlice.reducer
 
 export const selectIsAuthenticated = (state: RootState) =>
   state.auth.isAuthenticated
+export const selectUser = (state: RootState) => state.auth.user
 
 export function useAuth() {
   const dispatch = useAppDispatch()
   const isAuthenticated = useAppSelector(selectIsAuthenticated)
+  const user = useAppSelector(selectUser)
   return {
     isAuthenticated,
+    user,
     login: () => dispatch(login()),
     logout: () => dispatch(logout()),
   }


### PR DESCRIPTION
## Summary
- extend `authSlice` with dummy user info
- expose user info through `useAuth`
- create `ProfilePage` component styled with Tailwind to show user info and log out

## Testing
- `npm test` *(fails: spawn xvfb-run ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68585b973bf883228ef356a3445579ea