### PR TITLE
Add theme/unit settings

### DIFF
--- a/app/src/ProfilePage.tsx
+++ b/app/src/ProfilePage.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom'
 import { Button } from './components'
+import SettingsSection from './SettingsSection'
 import { useAuth } from './authSlice'
 
 export function ProfilePage() {
@@ -13,7 +14,7 @@ export function ProfilePage() {
   }
 
   return (
-    <div className="flex h-screen items-center justify-center bg-gray-900">
+    <div className="flex h-screen flex-col items-center justify-center space-y-4 bg-gray-900">
       <div className="w-full max-w-sm space-y-4 rounded-lg bg-[#101a23] p-6 text-white">
         <img
           src={`https://ui-avatars.com/api/?name=${user.username}`}
@@ -28,6 +29,7 @@ export function ProfilePage() {
           Log Out
         </Button>
       </div>
+      <SettingsSection />
     </div>
   )
 }

--- a/app/src/SettingsSection.tsx
+++ b/app/src/SettingsSection.tsx
@@ -1,0 +1,38 @@
+import { useEffect } from 'react'
+import { Switch } from './components'
+import { useSettings } from './settingsSlice'
+
+export default function SettingsSection() {
+  const { theme, distanceUnit, toggleTheme, setDistanceUnit } = useSettings()
+
+  useEffect(() => {
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark')
+    } else {
+      document.documentElement.classList.remove('dark')
+    }
+  }, [theme])
+
+  return (
+    <div className="w-full max-w-sm space-y-4 rounded-lg bg-[#101a23] p-6 text-white">
+      <div className="flex items-center justify-between">
+        <span>Dark Theme</span>
+        <Switch checked={theme === 'dark'} onChange={toggleTheme} />
+      </div>
+      <div className="space-y-1">
+        <label htmlFor="distanceUnit" className="text-sm font-medium">
+          Distance Unit
+        </label>
+        <select
+          id="distanceUnit"
+          value={distanceUnit}
+          onChange={(e) => setDistanceUnit(e.target.value as 'nm' | 'km')}
+          className="w-full rounded-md border border-gray-700 bg-gray-800 p-2 text-white focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          <option value="nm">Nautical Miles</option>
+          <option value="km">Kilometers</option>
+        </select>
+      </div>
+    </div>
+  )
+}

--- a/app/src/settingsSlice.ts
+++ b/app/src/settingsSlice.ts
@@ -1,0 +1,49 @@
+import { createSlice } from '@reduxjs/toolkit'
+import type { PayloadAction } from '@reduxjs/toolkit'
+import { useAppDispatch, useAppSelector } from './store'
+import type { RootState } from './store'
+
+export interface SettingsState {
+  theme: 'light' | 'dark'
+  distanceUnit: 'nm' | 'km'
+}
+
+const initialState: SettingsState = {
+  theme: 'light',
+  distanceUnit: 'nm',
+}
+
+const settingsSlice = createSlice({
+  name: 'settings',
+  initialState,
+  reducers: {
+    setTheme(state, action: PayloadAction<'light' | 'dark'>) {
+      state.theme = action.payload
+    },
+    toggleTheme(state) {
+      state.theme = state.theme === 'light' ? 'dark' : 'light'
+    },
+    setDistanceUnit(state, action: PayloadAction<'nm' | 'km'>) {
+      state.distanceUnit = action.payload
+    },
+  },
+})
+
+export const { setTheme, toggleTheme, setDistanceUnit } = settingsSlice.actions
+export default settingsSlice.reducer
+
+export const selectTheme = (state: RootState) => state.settings.theme
+export const selectDistanceUnit = (state: RootState) => state.settings.distanceUnit
+
+export function useSettings() {
+  const dispatch = useAppDispatch()
+  const theme = useAppSelector(selectTheme)
+  const distanceUnit = useAppSelector(selectDistanceUnit)
+  return {
+    theme,
+    distanceUnit,
+    toggleTheme: () => dispatch(toggleTheme()),
+    setTheme: (value: 'light' | 'dark') => dispatch(setTheme(value)),
+    setDistanceUnit: (unit: 'nm' | 'km') => dispatch(setDistanceUnit(unit)),
+  }
+}

--- a/app/src/store.ts
+++ b/app/src/store.ts
@@ -2,10 +2,12 @@ import { configureStore } from '@reduxjs/toolkit'
 import { useDispatch, useSelector } from 'react-redux'
 import type { TypedUseSelectorHook } from 'react-redux'
 import authReducer from './authSlice'
+import settingsReducer from './settingsSlice'
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
+    settings: settingsReducer,
   },
 })
 


### PR DESCRIPTION
## Summary
- add Redux slice for settings state
- create `SettingsSection` component with theme toggle and distance unit select
- render SettingsSection in ProfilePage
- register settings reducer in store

## Testing
- `npm test` *(fails: spawn xvfb-run ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68585c75107c8322bbb93eb03c81bef2