### PR TITLE
Add flights API slice

### DIFF
--- a/app/src/flightsSlice.ts
+++ b/app/src/flightsSlice.ts
@@ -1,0 +1,31 @@
+import { createApi, fetchBaseQuery } from '@reduxjs/toolkit/query/react'
+
+export interface Flight {
+  id: number
+  pilot: string
+  origin: string
+  destination: string
+  aircraft: string
+}
+
+const flights: Flight[] = [
+  { id: 1, pilot: 'John Doe', origin: 'KJFK', destination: 'KLAX', aircraft: 'B737' },
+  { id: 2, pilot: 'Jane Smith', origin: 'EGLL', destination: 'EHAM', aircraft: 'A320' },
+  { id: 3, pilot: 'Bob Brown', origin: 'KSEA', destination: 'CYYZ', aircraft: 'B777' },
+]
+
+export const flightsApi = createApi({
+  reducerPath: 'flightsApi',
+  baseQuery: fetchBaseQuery(),
+  endpoints: (builder) => ({
+    getActiveFlights: builder.query<Flight[], void>({
+      // Normally this would be `query: () => '/api/active-flights'`.
+      // For now return stubbed data.
+      async queryFn() {
+        return { data: flights }
+      },
+    }),
+  }),
+})
+
+export const { useGetActiveFlightsQuery } = flightsApi

--- a/app/src/store.ts
+++ b/app/src/store.ts
@@ -3,12 +3,16 @@ import { useDispatch, useSelector } from 'react-redux'
 import type { TypedUseSelectorHook } from 'react-redux'
 import authReducer from './authSlice'
 import settingsReducer from './settingsSlice'
+import { flightsApi } from './flightsSlice'
 
 export const store = configureStore({
   reducer: {
     auth: authReducer,
     settings: settingsReducer,
+    [flightsApi.reducerPath]: flightsApi.reducer,
   },
+  middleware: (getDefaultMiddleware) =>
+    getDefaultMiddleware().concat(flightsApi.middleware),
 })
 
 export type RootState = ReturnType<typeof store.getState>


### PR DESCRIPTION
## Summary
- add flights API slice using Redux Toolkit Query
- register flights API in store configuration

## Testing
- `npm test` *(fails: spawn xvfb-run ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68585d6364a48322af478e4b5254244c