### PR TITLE
Add Pagination component

### DIFF
--- a/app/src/components/Pagination.tsx
+++ b/app/src/components/Pagination.tsx
@@ -1,0 +1,43 @@
+import type { FC } from 'react'
+
+export interface PaginationProps {
+  current: number
+  totalPages: number
+  onChange: (page: number) => void
+}
+
+export const Pagination: FC<PaginationProps> = ({ current, totalPages, onChange }) => {
+  const prevDisabled = current <= 1
+  const nextDisabled = current >= totalPages
+
+  const goPrev = () => {
+    if (!prevDisabled) onChange(current - 1)
+  }
+
+  const goNext = () => {
+    if (!nextDisabled) onChange(current + 1)
+  }
+
+  return (
+    <div className="flex items-center gap-2">
+      <button
+        type="button"
+        onClick={goPrev}
+        disabled={prevDisabled}
+        className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        Previous
+      </button>
+      <button
+        type="button"
+        onClick={goNext}
+        disabled={nextDisabled}
+        className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm hover:bg-gray-100 disabled:cursor-not-allowed disabled:opacity-50"
+      >
+        Next
+      </button>
+    </div>
+  )
+}
+
+export default Pagination

--- a/app/src/components/index.ts
+++ b/app/src/components/index.ts
@@ -1,3 +1,4 @@
 export * from './DataTable'
+export * from './Pagination'
 export * from './ui'
 export * from './maps'


### PR DESCRIPTION
## Summary
- create `Pagination` component with Previous/Next buttons
- re-export `Pagination` from components index

## Testing
- `npm test` *(fails: spawn xvfb-run ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_68585f0ec39c83228bca07465dd86825