### PR TITLE
Add logbook page with CSV export

### DIFF
--- a/app/src/LogbookPage.tsx
+++ b/app/src/LogbookPage.tsx
@@ -1,0 +1,39 @@
+import { Button, Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from './components'
+import { useAppSelector } from './store'
+import { selectLogbook } from './logbookSlice'
+import { downloadCsv } from './downloadCsv'
+
+export function LogbookPage() {
+  const flights = useAppSelector(selectLogbook)
+
+  return (
+    <div className="space-y-4 p-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Logbook</h1>
+        <Button onClick={() => downloadCsv(flights)}>Export CSV</Button>
+      </div>
+      <Table className="bg-white">
+        <TableHeader>
+          <TableRow>
+            <TableHead>Date</TableHead>
+            <TableHead>Route</TableHead>
+            <TableHead>Duration</TableHead>
+            <TableHead>Landing Rate</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {flights.map((flight, idx) => (
+            <TableRow key={flight.id} className={idx % 2 ? 'bg-gray-50' : ''}>
+              <TableCell>{flight.date}</TableCell>
+              <TableCell>{flight.route}</TableCell>
+              <TableCell>{flight.duration}</TableCell>
+              <TableCell>{flight.landingRate}</TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  )
+}
+
+export default LogbookPage

--- a/app/src/downloadCsv.ts
+++ b/app/src/downloadCsv.ts
@@ -1,0 +1,15 @@
+export function downloadCsv<T extends Record<string, any>>(data: T[]) {
+  if (data.length === 0) return
+  const headers = Object.keys(data[0])
+  const rows = data.map((row) =>
+    headers.map((h) => JSON.stringify(row[h] ?? '')).join(',')
+  )
+  const csv = [headers.join(','), ...rows].join('\n')
+  const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' })
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement('a')
+  link.href = url
+  link.download = 'logbook.csv'
+  link.click()
+  URL.revokeObjectURL(url)
+}

--- a/app/src/logbookSlice.ts
+++ b/app/src/logbookSlice.ts
@@ -1,0 +1,31 @@
+import { createSlice } from '@reduxjs/toolkit'
+import { useAppSelector } from './store'
+import type { RootState } from './store'
+
+export interface LogEntry {
+  id: number
+  date: string
+  route: string
+  duration: string
+  landingRate: number
+}
+
+const initialState: LogEntry[] = [
+  { id: 1, date: '2024-05-01', route: 'KJFK-KLAX', duration: '05:30', landingRate: -120 },
+  { id: 2, date: '2024-05-05', route: 'EGLL-EDDM', duration: '01:45', landingRate: -250 },
+  { id: 3, date: '2024-05-10', route: 'KLAX-YSSY', duration: '14:00', landingRate: -180 },
+]
+
+const logbookSlice = createSlice({
+  name: 'logbook',
+  initialState,
+  reducers: {},
+})
+
+export default logbookSlice.reducer
+
+export const selectLogbook = (state: RootState) => state.logbook
+
+export function useLogbook() {
+  return useAppSelector(selectLogbook)
+}

--- a/app/src/store.ts
+++ b/app/src/store.ts
@@ -4,6 +4,7 @@ import type { TypedUseSelectorHook } from 'react-redux'
 import authReducer from './authSlice'
 import settingsReducer from './settingsSlice'
 import acarsReducer from './acarsSlice'
+import logbookReducer from './logbookSlice'
 import { flightsApi } from './flightsSlice'
 
 export const store = configureStore({
@@ -11,6 +12,7 @@ export const store = configureStore({
     auth: authReducer,
     settings: settingsReducer,
     acars: acarsReducer,
+    logbook: logbookReducer,
     [flightsApi.reducerPath]: flightsApi.reducer,
   },
   middleware: (getDefaultMiddleware) =>


### PR DESCRIPTION
## Summary
- add Redux slice for stubbed logbook data
- hook new logbook slice into the store
- implement a CSV download helper
- create `LogbookPage` with export button and alternating row styling

## Testing
- `npm test` *(fails: spawn xvfb-run ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6858622aeb488322a723f1efd1abc343