### PR TITLE
Add fleet management page

### DIFF
--- a/app/src/FleetPage.tsx
+++ b/app/src/FleetPage.tsx
@@ -1,0 +1,81 @@
+import { useState } from 'react'
+import { Button, Dialog, Input, Label } from './components'
+import { useFleet } from './fleetSlice'
+
+type Status = 'OK' | 'Needs Maintenance'
+
+export default function FleetPage() {
+  const { aircraft, addAircraft } = useFleet()
+  const [open, setOpen] = useState(false)
+  const [tail, setTail] = useState('')
+  const [hours, setHours] = useState('')
+  const [status, setStatus] = useState<Status>('OK')
+
+  function reset() {
+    setTail('')
+    setHours('')
+    setStatus('OK')
+  }
+
+  function handleSubmit() {
+    if (!tail) return
+    addAircraft({ tail, hours: Number(hours), status })
+    reset()
+    setOpen(false)
+  }
+
+  return (
+    <div className="space-y-4 p-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Fleet</h1>
+        <Button onClick={() => setOpen(true)}>Add Aircraft</Button>
+      </div>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {aircraft.map((ac) => (
+          <div
+            key={ac.tail}
+            className="space-y-1 rounded-lg border border-gray-200 bg-white p-4"
+          >
+            <div className="text-lg font-semibold">{ac.tail}</div>
+            <div className="text-sm text-gray-600">Hours: {ac.hours}</div>
+            <span
+              className={`inline-block rounded px-2 py-1 text-xs font-medium ${
+                ac.status === 'OK'
+                  ? 'bg-green-100 text-green-800'
+                  : 'bg-red-100 text-red-800'
+              }`}
+            >
+              {ac.status}
+            </span>
+          </div>
+        ))}
+      </div>
+      <Dialog open={open} onClose={() => setOpen(false)} title="Add Aircraft">
+        <div className="space-y-2">
+          <Label htmlFor="tail">Tail Number</Label>
+          <Input id="tail" value={tail} onChange={(e) => setTail(e.target.value)} />
+          <Label htmlFor="hours">Hours</Label>
+          <Input
+            id="hours"
+            type="number"
+            value={hours}
+            onChange={(e) => setHours(e.target.value)}
+          />
+          <Label htmlFor="status">Status</Label>
+          <select
+            id="status"
+            className="w-full rounded-md border border-gray-300 p-2 text-sm"
+            value={status}
+            onChange={(e) => setStatus(e.target.value as Status)}
+          >
+            <option value="OK">OK</option>
+            <option value="Needs Maintenance">Needs Maintenance</option>
+          </select>
+          <Button className="w-full" onClick={handleSubmit}>
+            Save
+          </Button>
+        </div>
+      </Dialog>
+    </div>
+  )
+}

--- a/app/src/fleetSlice.ts
+++ b/app/src/fleetSlice.ts
@@ -1,0 +1,38 @@
+import { createSlice } from '@reduxjs/toolkit'
+import type { PayloadAction } from '@reduxjs/toolkit'
+import { useAppDispatch, useAppSelector } from './store'
+import type { RootState } from './store'
+
+export interface Aircraft {
+  tail: string
+  hours: number
+  status: 'OK' | 'Needs Maintenance'
+}
+
+const initialState: Aircraft[] = [
+  { tail: 'N12345', hours: 120, status: 'OK' },
+]
+
+const fleetSlice = createSlice({
+  name: 'fleet',
+  initialState,
+  reducers: {
+    addAircraft(state, action: PayloadAction<Aircraft>) {
+      state.push(action.payload)
+    },
+  },
+})
+
+export const { addAircraft } = fleetSlice.actions
+export default fleetSlice.reducer
+
+export const selectFleet = (state: RootState) => state.fleet
+
+export function useFleet() {
+  const dispatch = useAppDispatch()
+  const aircraft = useAppSelector(selectFleet)
+  return {
+    aircraft,
+    addAircraft: (a: Aircraft) => dispatch(addAircraft(a)),
+  }
+}

--- a/app/src/store.ts
+++ b/app/src/store.ts
@@ -5,6 +5,7 @@ import authReducer from './authSlice'
 import settingsReducer from './settingsSlice'
 import acarsReducer from './acarsSlice'
 import logbookReducer from './logbookSlice'
+import fleetReducer from './fleetSlice'
 import { flightsApi } from './flightsSlice'
 
 export const store = configureStore({
@@ -13,6 +14,7 @@ export const store = configureStore({
     settings: settingsReducer,
     acars: acarsReducer,
     logbook: logbookReducer,
+    fleet: fleetReducer,
     [flightsApi.reducerPath]: flightsApi.reducer,
   },
   middleware: (getDefaultMiddleware) =>


### PR DESCRIPTION
## Summary
- implement fleetSlice for aircraft data
- create FleetPage with modal form for adding aircraft
- register fleet slice in the Redux store

## Testing
- `npm test` *(fails: spawn xvfb-run ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_685863f0227c832286b3e141b1bed29c