### PR TITLE
Refactor store hooks into separate module

### DIFF
--- a/app/src/LiveFlightPage.tsx
+++ b/app/src/LiveFlightPage.tsx
@@ -1,6 +1,6 @@
 import { Button, Gauge } from './components'
 import { startFlight, endFlight } from './acarsSlice'
-import { useAppDispatch } from './store'
+import { useAppDispatch } from './storeHooks'
 
 export default function LiveFlightPage() {
   const dispatch = useAppDispatch()

--- a/app/src/LogbookPage.tsx
+++ b/app/src/LogbookPage.tsx
@@ -1,5 +1,5 @@
 import { Button, Table, TableHeader, TableRow, TableHead, TableBody, TableCell } from './components'
-import { useAppSelector } from './store'
+import { useAppSelector } from './storeHooks'
 import { selectLogbook } from './logbookSlice'
 import { downloadCsv } from './downloadCsv'
 

--- a/app/src/ProtectedRoute.tsx
+++ b/app/src/ProtectedRoute.tsx
@@ -1,5 +1,5 @@
 import { Route, Navigate } from 'react-router-dom'
-import { useAppSelector } from './store'
+import { useAppSelector } from './storeHooks'
 import { selectIsAuthenticated } from './authSlice'
 import type { ReactElement } from 'react'
 

--- a/app/src/acarsSlice.ts
+++ b/app/src/acarsSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit'
 import type { PayloadAction } from '@reduxjs/toolkit'
-import { useAppDispatch, useAppSelector } from './store'
+import { useAppDispatch, useAppSelector } from './storeHooks'
 import type { AppDispatch, RootState } from './store'
 
 export interface DataPoint {

--- a/app/src/authSlice.ts
+++ b/app/src/authSlice.ts
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit'
-import { useAppDispatch, useAppSelector } from './store'
+import { useAppDispatch, useAppSelector } from './storeHooks'
 import type { RootState } from './store'
 
 export interface AuthState {

--- a/app/src/fleetSlice.ts
+++ b/app/src/fleetSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit'
 import type { PayloadAction } from '@reduxjs/toolkit'
-import { useAppDispatch, useAppSelector } from './store'
+import { useAppDispatch, useAppSelector } from './storeHooks'
 import type { RootState } from './store'
 
 export interface Aircraft {

--- a/app/src/logbookSlice.ts
+++ b/app/src/logbookSlice.ts
@@ -1,5 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit'
-import { useAppSelector } from './store'
+import { useAppSelector } from './storeHooks'
 import type { RootState } from './store'
 
 export interface LogEntry {

--- a/app/src/notificationsSlice.ts
+++ b/app/src/notificationsSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit'
 import type { PayloadAction } from '@reduxjs/toolkit'
-import { useAppDispatch, useAppSelector } from './store'
+import { useAppDispatch, useAppSelector } from './storeHooks'
 import type { RootState } from './store'
 
 export interface NotificationsState {

--- a/app/src/settingsSlice.ts
+++ b/app/src/settingsSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice } from '@reduxjs/toolkit'
 import type { PayloadAction } from '@reduxjs/toolkit'
-import { useAppDispatch, useAppSelector } from './store'
+import { useAppDispatch, useAppSelector } from './storeHooks'
 import type { RootState } from './store'
 
 export interface SettingsState {

--- a/app/src/store.ts
+++ b/app/src/store.ts
@@ -1,6 +1,4 @@
 import { configureStore } from '@reduxjs/toolkit'
-import { useDispatch, useSelector } from 'react-redux'
-import type { TypedUseSelectorHook } from 'react-redux'
 import authReducer from './authSlice'
 import settingsReducer from './settingsSlice'
 import acarsReducer from './acarsSlice'
@@ -25,6 +23,3 @@ export const store = configureStore({
 
 export type RootState = ReturnType<typeof store.getState>
 export type AppDispatch = typeof store.dispatch
-
-export const useAppDispatch: () => AppDispatch = useDispatch
-export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector

--- a/app/src/storeHooks.ts
+++ b/app/src/storeHooks.ts
@@ -1,0 +1,6 @@
+import type { TypedUseSelectorHook } from 'react-redux';
+import { useDispatch, useSelector } from 'react-redux';
+import type { AppDispatch, RootState } from './store';
+
+export const useAppDispatch: () => AppDispatch = useDispatch;
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector;


### PR DESCRIPTION
## Summary
- create `storeHooks.ts` and move dispatch/selector hooks there
- update `store.ts` to only export types and store
- update all imports to use `storeHooks`

## Testing
- `npm run verify` *(fails: spawn xvfb-run ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_685868a04ec88322bb8ec0d99c0e0431