### PR TITLE
Fix insecure CSP and localize placeholder assets

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -7,6 +7,10 @@
     <link href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&family=Noto+Sans:wght@400;500;700&display=swap" rel="stylesheet" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta
+      http-equiv="Content-Security-Policy"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src https://fonts.gstatic.com; img-src 'self' data:;"
+    />
     <title>Vite + React + TS</title>
   </head>
   <body>

--- a/app/public/images/placeholder-56.svg
+++ b/app/public/images/placeholder-56.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="56" height="56" viewBox="0 0 56 56">
+  <rect width="56" height="56" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="10" fill="#666">56x56</text>
+</svg>

--- a/app/public/images/placeholder-800x450.svg
+++ b/app/public/images/placeholder-800x450.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="800" height="450" viewBox="0 0 800 450">
+  <rect width="800" height="450" fill="#ddd"/>
+  <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-family="Arial, sans-serif" font-size="40" fill="#666">800x450</text>
+</svg>

--- a/app/src/components/CommunityHub.tsx
+++ b/app/src/components/CommunityHub.tsx
@@ -2,8 +2,18 @@ import { Calendar } from 'lucide-react'
 
 export default function CommunityHub() {
   const activities = [
-    { id: 1, pilot: 'John Doe', flight: 'VA123', avatar: 'https://via.placeholder.com/56' },
-    { id: 2, pilot: 'Jane Smith', flight: 'VA456', avatar: 'https://via.placeholder.com/56' },
+    {
+      id: 1,
+      pilot: 'John Doe',
+      flight: 'VA123',
+      avatar: '/images/placeholder-56.svg',
+    },
+    {
+      id: 2,
+      pilot: 'Jane Smith',
+      flight: 'VA456',
+      avatar: '/images/placeholder-56.svg',
+    },
   ]
 
   const events = [
@@ -21,7 +31,7 @@ export default function CommunityHub() {
       <section className="space-y-4">
         <h2 className="font-heading text-2xl">Active Flights</h2>
         <div className="aspect-video w-full overflow-hidden rounded-lg bg-[#223649]">
-          <img src="https://via.placeholder.com/800x450" alt="Map" className="h-full w-full object-cover" />
+          <img src="/images/placeholder-800x450.svg" alt="Map" className="h-full w-full object-cover" />
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- use local placeholder images in the CommunityHub component
- add a simple content security policy meta tag

## Testing
- `npm run verify`

------
https://chatgpt.com/codex/tasks/task_e_68586ffb2d2883228976ef0758f4af4d