### PR TITLE
Add full settings page

### DIFF
--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -11,6 +11,7 @@
         "@dnd-kit/core": "^6.1.0",
         "@dnd-kit/sortable": "^8.0.0",
         "@dnd-kit/utilities": "^3.2.2",
+        "@headlessui/react": "^1.7.18",
         "@reduxjs/toolkit": "^2.8.2",
         "@shadcn/ui": "^0.0.4",
         "clsx": "^2.1.0",
@@ -994,6 +995,23 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
+    "node_modules/@headlessui/react": {
+      "version": "1.7.19",
+      "resolved": "https://registry.npmjs.org/@headlessui/react/-/react-1.7.19.tgz",
+      "integrity": "sha512-Ll+8q3OlMJfJbAKM/+/Y2q6PPYbryqNTXDbryx7SXLIDamkF6iQFbriYHga0dY44PvDhvvBWCx1Xj4U5+G4hOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/react-virtual": "^3.0.0-beta.60",
+        "client-only": "^0.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": "^16 || ^17 || ^18",
+        "react-dom": "^16 || ^17 || ^18"
+      }
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -1556,6 +1574,33 @@
       },
       "peerDependencies": {
         "tailwindcss": ">=3.0.0 || >= 3.0.0-alpha.1 || >= 4.0.0-alpha.20 || >= 4.0.0-beta.1"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-virtual/-/react-virtual-3.13.10.tgz",
+      "integrity": "sha512-nvrzk4E9mWB4124YdJ7/yzwou7IfHxlSef6ugCFcBfRmsnsma3heciiiV97sBNxyc3VuwtZvmwXd0aB5BpucVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.13.10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.13.10",
+      "resolved": "https://registry.npmjs.org/@tanstack/virtual-core/-/virtual-core-3.13.10.tgz",
+      "integrity": "sha512-sPEDhXREou5HyZYqSWIqdU580rsF6FGeN7vpzijmP3KTiOGjOMZASz4Y6+QKjiFQwhWrR58OP8izYaNGVxvViA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@types/babel__core": {
@@ -2341,6 +2386,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
     },
     "node_modules/clone": {
       "version": "1.0.4",

--- a/app/package.json
+++ b/app/package.json
@@ -23,7 +23,8 @@
     "react-leaflet": "^5.0.0",
     "react-redux": "^9.2.0",
     "react-router-dom": "^7.6.2",
-    "tailwind-merge": "^3.3.1"
+    "tailwind-merge": "^3.3.1",
+    "@headlessui/react": "^1.7.18"
   },
   "devDependencies": {
     "@eslint/js": "^9.25.0",

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -7,7 +7,7 @@ import ProtectedRoute from './ProtectedRoute'
 import FlightsPage from './FlightsPage'
 import CommunityHub from './components/CommunityHub'
 import ProfilePage from './ProfilePage'
-import SettingsSection from './SettingsSection'
+import SettingsPage from './SettingsPage'
 
 function Placeholder({ title }: { title: string }) {
   return <div className="p-6 text-white">{title}</div>
@@ -45,7 +45,7 @@ export default function App() {
             <Route path="flights" element={<FlightsPage />} />
             <Route path="community" element={<CommunityHub />} />
             <Route path="roster" element={<Placeholder title="Roster" />} />
-            <Route path="settings" element={<SettingsSection />} />
+            <Route path="settings" element={<SettingsPage />} />
             <Route path="profile" element={<ProfilePage />} />
           </Route>
         </Route>

--- a/app/src/SettingsPage.tsx
+++ b/app/src/SettingsPage.tsx
@@ -1,0 +1,154 @@
+import { useEffect } from 'react'
+import { Switch } from '@headlessui/react'
+import { useSettings } from './settingsSlice'
+
+export default function SettingsPage() {
+  const {
+    theme,
+    distanceUnit,
+    speedUnit,
+    altitudeUnit,
+    mapStyle,
+    notificationsPush,
+    notificationsEmail,
+    acarsPollInterval,
+    toggleTheme,
+    setDistanceUnit,
+    setSpeedUnit,
+    setAltitudeUnit,
+    setMapStyle,
+    setNotificationsPush,
+    setNotificationsEmail,
+    setAcarsPollInterval,
+  } = useSettings()
+
+  useEffect(() => {
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark')
+    } else {
+      document.documentElement.classList.remove('dark')
+    }
+  }, [theme])
+
+  return (
+    <div className="max-w-md space-y-4 rounded-lg bg-gray-800 p-6 text-white">
+      <div className="flex items-center justify-between">
+        <span>Dark Theme</span>
+        <Switch
+          checked={theme === 'dark'}
+          onChange={() => toggleTheme()}
+          className={`${
+            theme === 'dark' ? 'bg-blue-600' : 'bg-gray-200'
+          } relative inline-flex h-6 w-11 items-center rounded-full`}
+        >
+          <span className="sr-only">Toggle Theme</span>
+          <span
+            className={`${
+              theme === 'dark' ? 'translate-x-6' : 'translate-x-1'
+            } inline-block h-4 w-4 transform rounded-full bg-white transition`}
+          />
+        </Switch>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <span>Distance Unit</span>
+        <select
+          value={distanceUnit}
+          onChange={(e) => setDistanceUnit(e.target.value as 'nm' | 'km')}
+          className="rounded-md bg-gray-700 p-2"
+        >
+          <option value="nm">Nautical Miles</option>
+          <option value="km">Kilometers</option>
+        </select>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <span>Speed Unit</span>
+        <select
+          value={speedUnit}
+          onChange={(e) => setSpeedUnit(e.target.value as 'kt' | 'kmh')}
+          className="rounded-md bg-gray-700 p-2"
+        >
+          <option value="kt">Knots</option>
+          <option value="kmh">km/h</option>
+        </select>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <span>Altitude Unit</span>
+        <select
+          value={altitudeUnit}
+          onChange={(e) => setAltitudeUnit(e.target.value as 'ft' | 'm')}
+          className="rounded-md bg-gray-700 p-2"
+        >
+          <option value="ft">Feet</option>
+          <option value="m">Meters</option>
+        </select>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <span>Map Style</span>
+        <select
+          value={mapStyle}
+          onChange={(e) => setMapStyle(e.target.value as 'day' | 'night' | 'auto')}
+          className="rounded-md bg-gray-700 p-2"
+        >
+          <option value="day">Day</option>
+          <option value="night">Night</option>
+          <option value="auto">Auto</option>
+        </select>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <span>Push Notifications</span>
+        <Switch
+          checked={notificationsPush}
+          onChange={setNotificationsPush}
+          className={`${
+            notificationsPush ? 'bg-blue-600' : 'bg-gray-200'
+          } relative inline-flex h-6 w-11 items-center rounded-full`}
+        >
+          <span className="sr-only">Toggle Push Notifications</span>
+          <span
+            className={`${
+              notificationsPush ? 'translate-x-6' : 'translate-x-1'
+            } inline-block h-4 w-4 transform rounded-full bg-white transition`}
+          />
+        </Switch>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <span>Email Notifications</span>
+        <Switch
+          checked={notificationsEmail}
+          onChange={setNotificationsEmail}
+          className={`${
+            notificationsEmail ? 'bg-blue-600' : 'bg-gray-200'
+          } relative inline-flex h-6 w-11 items-center rounded-full`}
+        >
+          <span className="sr-only">Toggle Email Notifications</span>
+          <span
+            className={`${
+              notificationsEmail ? 'translate-x-6' : 'translate-x-1'
+            } inline-block h-4 w-4 transform rounded-full bg-white transition`}
+          />
+        </Switch>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <span>ACARS Poll Interval</span>
+        <select
+          value={acarsPollInterval}
+          onChange={(e) =>
+            setAcarsPollInterval(parseInt(e.target.value) as 1 | 5 | 10)
+          }
+          className="rounded-md bg-gray-700 p-2"
+        >
+          <option value={1}>1s</option>
+          <option value={5}>5s</option>
+          <option value={10}>10s</option>
+        </select>
+      </div>
+    </div>
+  )
+}

--- a/app/src/settingsSlice.ts
+++ b/app/src/settingsSlice.ts
@@ -6,11 +6,23 @@ import type { RootState } from './store'
 export interface SettingsState {
   theme: 'light' | 'dark'
   distanceUnit: 'nm' | 'km'
+  speedUnit: 'kt' | 'kmh'
+  altitudeUnit: 'ft' | 'm'
+  mapStyle: 'day' | 'night' | 'auto'
+  notificationsPush: boolean
+  notificationsEmail: boolean
+  acarsPollInterval: 1 | 5 | 10
 }
 
 const initialState: SettingsState = {
   theme: 'light',
   distanceUnit: 'nm',
+  speedUnit: 'kt',
+  altitudeUnit: 'ft',
+  mapStyle: 'auto',
+  notificationsPush: true,
+  notificationsEmail: true,
+  acarsPollInterval: 1,
 }
 
 const settingsSlice = createSlice({
@@ -26,24 +38,79 @@ const settingsSlice = createSlice({
     setDistanceUnit(state, action: PayloadAction<'nm' | 'km'>) {
       state.distanceUnit = action.payload
     },
+    setSpeedUnit(state, action: PayloadAction<'kt' | 'kmh'>) {
+      state.speedUnit = action.payload
+    },
+    setAltitudeUnit(state, action: PayloadAction<'ft' | 'm'>) {
+      state.altitudeUnit = action.payload
+    },
+    setMapStyle(state, action: PayloadAction<'day' | 'night' | 'auto'>) {
+      state.mapStyle = action.payload
+    },
+    setNotificationsPush(state, action: PayloadAction<boolean>) {
+      state.notificationsPush = action.payload
+    },
+    setNotificationsEmail(state, action: PayloadAction<boolean>) {
+      state.notificationsEmail = action.payload
+    },
+    setAcarsPollInterval(state, action: PayloadAction<1 | 5 | 10>) {
+      state.acarsPollInterval = action.payload
+    },
   },
 })
 
-export const { setTheme, toggleTheme, setDistanceUnit } = settingsSlice.actions
+export const {
+  setTheme,
+  toggleTheme,
+  setDistanceUnit,
+  setSpeedUnit,
+  setAltitudeUnit,
+  setMapStyle,
+  setNotificationsPush,
+  setNotificationsEmail,
+  setAcarsPollInterval,
+} = settingsSlice.actions
 export default settingsSlice.reducer
 
 export const selectTheme = (state: RootState) => state.settings.theme
 export const selectDistanceUnit = (state: RootState) => state.settings.distanceUnit
+export const selectSpeedUnit = (state: RootState) => state.settings.speedUnit
+export const selectAltitudeUnit = (state: RootState) => state.settings.altitudeUnit
+export const selectMapStyle = (state: RootState) => state.settings.mapStyle
+export const selectNotificationsPush = (state: RootState) =>
+  state.settings.notificationsPush
+export const selectNotificationsEmail = (state: RootState) =>
+  state.settings.notificationsEmail
+export const selectAcarsPollInterval = (state: RootState) =>
+  state.settings.acarsPollInterval
 
 export function useSettings() {
   const dispatch = useAppDispatch()
   const theme = useAppSelector(selectTheme)
   const distanceUnit = useAppSelector(selectDistanceUnit)
+  const speedUnit = useAppSelector(selectSpeedUnit)
+  const altitudeUnit = useAppSelector(selectAltitudeUnit)
+  const mapStyle = useAppSelector(selectMapStyle)
+  const notificationsPush = useAppSelector(selectNotificationsPush)
+  const notificationsEmail = useAppSelector(selectNotificationsEmail)
+  const acarsPollInterval = useAppSelector(selectAcarsPollInterval)
   return {
     theme,
     distanceUnit,
+    speedUnit,
+    altitudeUnit,
+    mapStyle,
+    notificationsPush,
+    notificationsEmail,
+    acarsPollInterval,
     toggleTheme: () => dispatch(toggleTheme()),
     setTheme: (value: 'light' | 'dark') => dispatch(setTheme(value)),
     setDistanceUnit: (unit: 'nm' | 'km') => dispatch(setDistanceUnit(unit)),
+    setSpeedUnit: (unit: 'kt' | 'kmh') => dispatch(setSpeedUnit(unit)),
+    setAltitudeUnit: (unit: 'ft' | 'm') => dispatch(setAltitudeUnit(unit)),
+    setMapStyle: (style: 'day' | 'night' | 'auto') => dispatch(setMapStyle(style)),
+    setNotificationsPush: (val: boolean) => dispatch(setNotificationsPush(val)),
+    setNotificationsEmail: (val: boolean) => dispatch(setNotificationsEmail(val)),
+    setAcarsPollInterval: (val: 1 | 5 | 10) => dispatch(setAcarsPollInterval(val)),
   }
 }


### PR DESCRIPTION
## Summary
- add Headless UI dependency
- implement comprehensive settings slice
- create new `SettingsPage` with tailwind layout and headless switches
- route to the new page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858752cd16c832296dc2f20eec21c6b