### PR TITLE
Add roster feature with pilot cards

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -8,6 +8,7 @@ import FlightsPage from './FlightsPage'
 import CommunityHub from './components/CommunityHub'
 import ProfilePage from './ProfilePage'
 import SettingsPage from './SettingsPage'
+import RosterPage from './RosterPage'
 
 function Placeholder({ title }: { title: string }) {
   return <div className="p-6 text-white">{title}</div>
@@ -42,7 +43,7 @@ export default function App() {
             <Route path="dashboard" element={<Placeholder title="Dashboard" />} />
             <Route path="flights" element={<FlightsPage />} />
             <Route path="community" element={<CommunityHub />} />
-            <Route path="roster" element={<Placeholder title="Roster" />} />
+            <Route path="roster" element={<RosterPage />} />
             <Route path="settings" element={<SettingsPage />} />
             <Route path="profile" element={<ProfilePage />} />
           </Route>

--- a/app/src/RosterPage.tsx
+++ b/app/src/RosterPage.tsx
@@ -1,0 +1,30 @@
+import { useRoster } from './rosterSlice'
+
+export default function RosterPage() {
+  const pilots = useRoster()
+
+  return (
+    <div className="space-y-4 p-4">
+      <h1 className="text-2xl font-bold text-white">Roster</h1>
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {pilots.map((pilot) => (
+          <div
+            key={pilot.id}
+            className="flex flex-col items-center rounded-lg bg-gray-800 p-4 text-white"
+          >
+            <img
+              src={pilot.avatarUrl}
+              alt={pilot.name}
+              className="h-24 w-24 rounded-full"
+            />
+            <div className="mt-2 text-lg font-semibold">{pilot.name}</div>
+            <span className="mt-1 rounded bg-blue-600 px-2 text-white">
+              {pilot.callsign}
+            </span>
+            <div className="mt-2 text-sm">Total Hours: {pilot.totalHours}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/app/src/rosterSlice.ts
+++ b/app/src/rosterSlice.ts
@@ -1,0 +1,49 @@
+import { createSlice } from '@reduxjs/toolkit'
+import { useAppSelector } from './storeHooks'
+import type { RootState } from './store'
+
+export interface Pilot {
+  id: number
+  name: string
+  callsign: string
+  avatarUrl: string
+  totalHours: number
+}
+
+const initialState: Pilot[] = [
+  {
+    id: 1,
+    name: 'John Doe',
+    callsign: 'EAGLE1',
+    avatarUrl: 'https://ui-avatars.com/api/?name=John+Doe',
+    totalHours: 120,
+  },
+  {
+    id: 2,
+    name: 'Jane Smith',
+    callsign: 'HAWK2',
+    avatarUrl: 'https://ui-avatars.com/api/?name=Jane+Smith',
+    totalHours: 200,
+  },
+  {
+    id: 3,
+    name: 'Bob Brown',
+    callsign: 'FALCON3',
+    avatarUrl: 'https://ui-avatars.com/api/?name=Bob+Brown',
+    totalHours: 75,
+  },
+]
+
+const rosterSlice = createSlice({
+  name: 'roster',
+  initialState,
+  reducers: {},
+})
+
+export default rosterSlice.reducer
+
+export const selectRoster = (state: RootState) => state.roster
+
+export function useRoster() {
+  return useAppSelector(selectRoster)
+}

--- a/app/src/store.ts
+++ b/app/src/store.ts
@@ -6,6 +6,7 @@ import logbookReducer from './logbookSlice'
 import fleetReducer from './fleetSlice'
 import flightsReducer from './flightsSlice'
 import notificationsReducer from './notificationsSlice'
+import rosterReducer from './rosterSlice'
 
 export const store = configureStore({
   reducer: {
@@ -16,6 +17,7 @@ export const store = configureStore({
     fleet: fleetReducer,
     flights: flightsReducer,
     notifications: notificationsReducer,
+    roster: rosterReducer,
   },
   middleware: (getDefaultMiddleware) => getDefaultMiddleware(),
 })


### PR DESCRIPTION
## Summary
- build roster slice with sample pilots
- display roster grid in new `RosterPage`
- wire roster to Redux store
- route `/roster` to the new page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685879b9bab08322995647e5b3b6bd74