### PR TITLE
Add PilotCard component for roster

### DIFF
--- a/app/src/PilotCard.tsx
+++ b/app/src/PilotCard.tsx
@@ -1,0 +1,27 @@
+import { UserCircle } from 'lucide-react'
+import type { Pilot } from './rosterSlice'
+
+interface PilotCardProps {
+  pilot: Pilot
+}
+
+export default function PilotCard({ pilot }: PilotCardProps) {
+  const { avatarUrl, name, callsign, totalHours } = pilot
+
+  return (
+    <div className="flex flex-col items-center rounded-lg bg-gray-800 px-4 py-6 text-white">
+      {avatarUrl ? (
+        <img
+          src={avatarUrl}
+          alt={name}
+          className="h-[60px] w-[60px] rounded-full object-cover"
+        />
+      ) : (
+        <UserCircle className="h-[60px] w-[60px] rounded-full text-gray-500" />
+      )}
+      <div className="mt-2 max-w-full truncate text-lg font-semibold">{name}</div>
+      <span className="mt-1 rounded bg-blue-600 px-2 text-white">{callsign}</span>
+      <div className="mt-2 text-sm">Total Hours: {totalHours}</div>
+    </div>
+  )
+}

--- a/app/src/RosterPage.tsx
+++ b/app/src/RosterPage.tsx
@@ -1,4 +1,5 @@
 import { useRoster } from './rosterSlice'
+import PilotCard from './PilotCard'
 
 export default function RosterPage() {
   const pilots = useRoster()
@@ -7,22 +8,8 @@ export default function RosterPage() {
     <div className="space-y-4 p-4">
       <h1 className="text-2xl font-bold text-white">Roster</h1>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {pilots.map((pilot) => (
-          <div
-            key={pilot.id}
-            className="flex flex-col items-center rounded-lg bg-gray-800 p-4 text-white"
-          >
-            <img
-              src={pilot.avatarUrl}
-              alt={pilot.name}
-              className="h-24 w-24 rounded-full"
-            />
-            <div className="mt-2 text-lg font-semibold">{pilot.name}</div>
-            <span className="mt-1 rounded bg-blue-600 px-2 text-white">
-              {pilot.callsign}
-            </span>
-            <div className="mt-2 text-sm">Total Hours: {pilot.totalHours}</div>
-          </div>
+        {pilots.map(pilot => (
+          <PilotCard key={pilot.id} pilot={pilot} />
         ))}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- simplify roster page by introducing `PilotCard`
- ensure pilot names truncate correctly
- display a 60×60px avatar or fallback icon

## Testing
- `npm --prefix app run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858842bb5dc8322a7c9a8007cd71933