### PR TITLE
Improve notification bell and sticky headers

### DIFF
--- a/app/src/FlightsPage.tsx
+++ b/app/src/FlightsPage.tsx
@@ -95,7 +95,7 @@ export default function FlightsPage() {
         onDragEnd={handleDragEnd}
       >
         <table className="w-full border-collapse text-sm">
-          <thead className="bg-gray-900">
+          <thead className="bg-gray-900 text-gray-300 sticky top-0">
             <tr>
               <th className="px-3 py-2 text-left font-semibold text-gray-400">Pilot</th>
               <th className="px-3 py-2 text-left font-semibold text-gray-400">Origin</th>

--- a/app/src/components/NotificationBell.tsx
+++ b/app/src/components/NotificationBell.tsx
@@ -28,9 +28,9 @@ export default function NotificationBell() {
         className="relative rounded-full p-2"
         onClick={() => setOpen(!open)}
       >
-        <Bell className="text-white text-xl" />
+        <Bell className="h-6 w-6 text-white" />
         {unreadCount > 0 && (
-          <span className="absolute -right-1 -top-1 flex h-3 w-3 items-center justify-center rounded-full bg-red-600 text-xs text-white">
+          <span className="absolute top-0 right-0 flex h-3 w-3 items-center justify-center rounded-full bg-red-600 text-xs text-white">
             {unreadCount}
           </span>
         )}

--- a/app/src/components/ui/table.tsx
+++ b/app/src/components/ui/table.tsx
@@ -7,7 +7,12 @@ export const Table = forwardRef<HTMLTableElement, HTMLAttributes<HTMLTableElemen
 })
 
 export function TableHeader({ className, ...props }: HTMLAttributes<HTMLTableSectionElement>) {
-  return <thead className={cn('bg-gray-100', className)} {...props} />
+  return (
+    <thead
+      className={cn('bg-gray-900 text-gray-300 sticky top-0', className)}
+      {...props}
+    />
+  )
 }
 
 export function TableBody({ className, ...props }: HTMLAttributes<HTMLTableSectionElement>) {


### PR DESCRIPTION
## Summary
- tweak NotificationBell badge and icon size
- make all table headers sticky via TableHeader
- apply sticky header classes in FlightsPage

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685884721f588322944a397f0fcaa40d