### PR TITLE
Implement full dark/light theme toggle

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -13,7 +13,7 @@
     />
     <title>Vite + React + TS</title>
   </head>
-  <body>
+  <body class="min-h-screen bg-white text-gray-900 dark:bg-[#101a23] dark:text-white">
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -22,7 +22,7 @@ function ProtectedLayout() {
         className={`flex flex-1 flex-col transition-all lg:ml-80 ${open ? 'ml-80' : 'ml-16'}`}
       >
         <Header />
-        <main className="flex-1 p-4 text-white">
+        <main className="flex-1 p-4 text-gray-900 dark:text-white">
           <Outlet />
         </main>
       </div>

--- a/app/src/FlightsPage.tsx
+++ b/app/src/FlightsPage.tsx
@@ -32,7 +32,7 @@ function SortableRow({ flight }: { flight: Flight }) {
       style={style}
       {...attributes}
       {...listeners}
-      className="bg-gray-800 text-white border-b last:border-b-0"
+      className="border-b bg-white text-gray-900 last:border-b-0 dark:bg-gray-800 dark:text-white"
     >
       <td className="px-3 py-2">
         <span className="flex items-center gap-2">
@@ -95,7 +95,7 @@ export default function FlightsPage() {
         onDragEnd={handleDragEnd}
       >
         <table className="w-full border-collapse text-sm">
-          <thead className="bg-gray-900 text-gray-300 sticky top-0">
+          <thead className="sticky top-0 bg-gray-200 text-gray-700 dark:bg-gray-900 dark:text-gray-300">
             <tr>
               <th className="px-3 py-2 text-left font-semibold text-gray-400">Pilot</th>
               <th className="px-3 py-2 text-left font-semibold text-gray-400">Origin</th>

--- a/app/src/HomePage.tsx
+++ b/app/src/HomePage.tsx
@@ -28,19 +28,19 @@ export default function HomePage() {
     <div className="space-y-6">
       <h1 className="text-2xl font-bold">Dashboard</h1>
       <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-        <div className="flex items-center justify-between rounded-lg bg-gray-800 p-4">
+        <div className="flex items-center justify-between rounded-lg bg-gray-200 p-4 dark:bg-gray-800">
           <span>Total Flights</span>
           <span className="text-3xl font-bold">{totalFlights}</span>
         </div>
-        <div className="flex items-center justify-between rounded-lg bg-gray-800 p-4">
+        <div className="flex items-center justify-between rounded-lg bg-gray-200 p-4 dark:bg-gray-800">
           <span>Total Hours</span>
           <span className="text-3xl font-bold">{totalHours.toFixed(1)}</span>
         </div>
-        <div className="flex items-center justify-between rounded-lg bg-gray-800 p-4">
+        <div className="flex items-center justify-between rounded-lg bg-gray-200 p-4 dark:bg-gray-800">
           <span>Active Flights</span>
           <span className="text-3xl font-bold">{activeFlights}</span>
         </div>
-        <div className="flex items-center justify-between rounded-lg bg-gray-800 p-4">
+        <div className="flex items-center justify-between rounded-lg bg-gray-200 p-4 dark:bg-gray-800">
           <span>Upcoming Events</span>
           <span className="text-3xl font-bold">{events.length}</span>
         </div>
@@ -49,7 +49,7 @@ export default function HomePage() {
       <div className="space-y-2">
         <h2 className="text-xl font-semibold">Recent Flights</h2>
         <table className="w-full border-collapse text-sm">
-          <thead className="bg-gray-900">
+          <thead className="bg-gray-200 dark:bg-gray-900">
             <tr>
               <th className="px-3 py-2 text-left font-semibold text-gray-400">Date</th>
               <th className="px-3 py-2 text-left font-semibold text-gray-400">Route</th>
@@ -59,7 +59,7 @@ export default function HomePage() {
           </thead>
           <tbody>
             {recent.map((f) => (
-              <tr key={f.id} className="border-b bg-gray-800 text-white last:border-b-0">
+              <tr key={f.id} className="border-b bg-white text-gray-900 last:border-b-0 dark:bg-gray-800 dark:text-white">
                 <td className="px-3 py-2">{f.date}</td>
                 <td className="px-3 py-2">{f.route}</td>
                 <td className="px-3 py-2">{f.duration}</td>

--- a/app/src/LoginScreen.tsx
+++ b/app/src/LoginScreen.tsx
@@ -21,7 +21,7 @@ export function LoginScreen() {
   }
 
   return (
-    <div className="flex h-screen items-center justify-center bg-gray-100">
+    <div className="flex h-screen items-center justify-center bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-white">
       <form
         onSubmit={handleSubmit}
         className="w-full max-w-sm space-y-4 rounded-md bg-white p-6 shadow"
@@ -33,7 +33,7 @@ export function LoginScreen() {
             value={username}
             onChange={(e) => setUsername(e.target.value)}
             placeholder="Username"
-            className="bg-gray-700 text-white placeholder-gray-400 border border-gray-600 rounded-lg px-4 py-2"
+            className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-gray-900 placeholder-gray-400 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
           />
         </div>
         <div className="space-y-1">
@@ -44,7 +44,7 @@ export function LoginScreen() {
             value={password}
             onChange={(e) => setPassword(e.target.value)}
             placeholder="Password"
-            className="bg-gray-700 text-white placeholder-gray-400 border border-gray-600 rounded-lg px-4 py-2"
+            className="rounded-lg border border-gray-300 bg-white px-4 py-2 text-gray-900 placeholder-gray-400 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
           />
         </div>
         {error && <p className="text-sm text-red-500">{error}</p>}

--- a/app/src/PilotCard.tsx
+++ b/app/src/PilotCard.tsx
@@ -9,7 +9,7 @@ export default function PilotCard({ pilot }: PilotCardProps) {
   const { avatarUrl, name, callsign, totalHours } = pilot
 
   return (
-    <div className="flex flex-col items-center rounded-lg bg-gray-800 px-4 py-6 text-white">
+    <div className="flex flex-col items-center rounded-lg bg-white px-4 py-6 text-gray-900 dark:bg-gray-800 dark:text-white">
       {avatarUrl ? (
         <img
           src={avatarUrl}

--- a/app/src/ProfilePage.tsx
+++ b/app/src/ProfilePage.tsx
@@ -14,8 +14,8 @@ export function ProfilePage() {
   }
 
   return (
-    <div className="flex h-screen flex-col items-center justify-center space-y-4 bg-gray-900">
-      <div className="w-full max-w-sm space-y-4 rounded-lg bg-[#101a23] p-6 text-white">
+    <div className="flex h-screen flex-col items-center justify-center space-y-4 bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-white">
+      <div className="w-full max-w-sm space-y-4 rounded-lg bg-white p-6 text-gray-900 dark:bg-[#101a23] dark:text-white">
         <img
           src={`https://ui-avatars.com/api/?name=${user.username}`}
           alt="avatar"

--- a/app/src/RosterPage.tsx
+++ b/app/src/RosterPage.tsx
@@ -6,7 +6,7 @@ export default function RosterPage() {
 
   return (
     <div className="space-y-4 p-4">
-      <h1 className="text-2xl font-bold text-white">Roster</h1>
+      <h1 className="text-2xl font-bold text-gray-900 dark:text-white">Roster</h1>
       <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
         {pilots.map(pilot => (
           <PilotCard key={pilot.id} pilot={pilot} />

--- a/app/src/SettingsPage.tsx
+++ b/app/src/SettingsPage.tsx
@@ -31,7 +31,7 @@ export default function SettingsPage() {
   }, [theme])
 
   return (
-    <div className="max-w-md space-y-4 rounded-lg bg-gray-800 p-6 text-white">
+    <div className="max-w-md space-y-4 rounded-lg bg-gray-100 p-6 text-gray-900 dark:bg-gray-800 dark:text-white">
       <div className="flex items-center justify-between">
         <span>Dark Theme</span>
         <Switch
@@ -48,7 +48,7 @@ export default function SettingsPage() {
         <select
           value={distanceUnit}
           onChange={(e) => setDistanceUnit(e.target.value as 'nm' | 'km')}
-          className="rounded-md bg-gray-700 p-2"
+          className="rounded-md bg-white p-2 text-gray-900 dark:bg-gray-700 dark:text-white"
         >
           <option value="nm">Nautical Miles</option>
           <option value="km">Kilometers</option>
@@ -60,7 +60,7 @@ export default function SettingsPage() {
         <select
           value={speedUnit}
           onChange={(e) => setSpeedUnit(e.target.value as 'kt' | 'kmh')}
-          className="rounded-md bg-gray-700 p-2"
+          className="rounded-md bg-white p-2 text-gray-900 dark:bg-gray-700 dark:text-white"
         >
           <option value="kt">Knots</option>
           <option value="kmh">km/h</option>
@@ -72,7 +72,7 @@ export default function SettingsPage() {
         <select
           value={altitudeUnit}
           onChange={(e) => setAltitudeUnit(e.target.value as 'ft' | 'm')}
-          className="rounded-md bg-gray-700 p-2"
+          className="rounded-md bg-white p-2 text-gray-900 dark:bg-gray-700 dark:text-white"
         >
           <option value="ft">Feet</option>
           <option value="m">Meters</option>
@@ -84,7 +84,7 @@ export default function SettingsPage() {
         <select
           value={mapStyle}
           onChange={(e) => setMapStyle(e.target.value as 'day' | 'night' | 'auto')}
-          className="rounded-md bg-gray-700 p-2"
+          className="rounded-md bg-white p-2 text-gray-900 dark:bg-gray-700 dark:text-white"
         >
           <option value="day">Day</option>
           <option value="night">Night</option>
@@ -121,7 +121,7 @@ export default function SettingsPage() {
           onChange={(e) =>
             setAcarsPollInterval(parseInt(e.target.value) as 1 | 5 | 10)
           }
-          className="rounded-md bg-gray-700 p-2"
+          className="rounded-md bg-white p-2 text-gray-900 dark:bg-gray-700 dark:text-white"
         >
           <option value={1}>1s</option>
           <option value={5}>5s</option>

--- a/app/src/SettingsSection.tsx
+++ b/app/src/SettingsSection.tsx
@@ -20,7 +20,7 @@ export default function SettingsSection() {
   }, [theme])
 
   return (
-    <div className="w-full max-w-sm space-y-4 rounded-lg bg-gray-800 p-6 text-white">
+    <div className="w-full max-w-sm space-y-4 rounded-lg bg-gray-100 p-6 text-gray-900 dark:bg-gray-800 dark:text-white">
       <div className="flex items-center justify-between">
         <span>Dark Theme</span>
         <Switch
@@ -38,7 +38,7 @@ export default function SettingsSection() {
         <label className="text-sm font-medium">Distance Unit</label>
         <Listbox value={distanceUnit} onChange={setDistanceUnit}>
           <div className="relative">
-            <Listbox.Button className="relative flex min-w-[8rem] cursor-default items-center justify-between rounded-md bg-gray-700 py-1.5 pl-3 pr-8 text-left focus:outline-none">
+            <Listbox.Button className="relative flex min-w-[8rem] cursor-default items-center justify-between rounded-md bg-white py-1.5 pl-3 pr-8 text-left focus:outline-none dark:bg-gray-700 dark:text-white">
               <span className="block truncate">
                 {distanceOptions.find((o) => o.value === distanceUnit)?.label}
               </span>
@@ -46,7 +46,7 @@ export default function SettingsSection() {
                 <ChevronDown className="h-4 w-4 text-gray-400" aria-hidden="true" />
               </span>
             </Listbox.Button>
-            <Listbox.Options className="absolute z-10 mt-1 w-full rounded-md bg-gray-700 py-1 text-sm shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none">
+            <Listbox.Options className="absolute z-10 mt-1 w-full rounded-md bg-white py-1 text-sm shadow-lg ring-1 ring-black ring-opacity-5 focus:outline-none dark:bg-gray-700 dark:text-white">
               {distanceOptions.map((option) => (
                 <Listbox.Option
                   key={option.value}

--- a/app/src/components/CommunityHub.tsx
+++ b/app/src/components/CommunityHub.tsx
@@ -71,7 +71,7 @@ export default function CommunityHub() {
           {activities.map(act => (
             <div
               key={act.id}
-              className="flex min-w-[150px] items-center gap-3 rounded-lg bg-gray-800 p-3 flex-shrink-0"
+              className="flex min-w-[150px] items-center gap-3 rounded-lg bg-gray-200 p-3 flex-shrink-0 dark:bg-gray-800"
             >
               <img src={act.avatar} alt="avatar" className="h-10 w-10 rounded-full object-cover" />
               <div className="flex flex-col">
@@ -89,9 +89,9 @@ export default function CommunityHub() {
           {events.map(ev => (
             <div
               key={ev.id}
-              className="flex items-center gap-3 rounded-lg bg-[#101a23] p-4"
+              className="flex items-center gap-3 rounded-lg bg-gray-200 p-4 dark:bg-[#101a23]"
             >
-              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-[#223649]">
+              <div className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-600 dark:bg-[#223649]">
                 <Calendar className="h-5 w-5" />
               </div>
               <div className="flex flex-col">

--- a/app/src/components/DataTable.tsx
+++ b/app/src/components/DataTable.tsx
@@ -146,7 +146,7 @@ export function DataTable<T extends { id: number | string }>({
           setPage(0)
         }}
         placeholder="Filter..."
-        className="w-full rounded-md border px-3 py-2"
+        className="w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-gray-900 dark:border-gray-600 dark:bg-gray-700 dark:text-white"
       />
       <DndContext
         sensors={sensors}

--- a/app/src/components/Gauge.tsx
+++ b/app/src/components/Gauge.tsx
@@ -4,7 +4,7 @@ export interface GaugeProps {
 
 export function Gauge({ label }: GaugeProps) {
   return (
-    <div className="flex flex-col items-center gap-2">
+    <div className="flex flex-col items-center gap-2 text-gray-900 dark:text-white">
       <div className="flex h-24 w-24 items-center justify-center rounded-full border-2 border-gray-400 dark:border-gray-600">
         <span className="text-lg font-bold">--</span>
       </div>

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -2,7 +2,7 @@ import NotificationBell from './NotificationBell'
 
 export default function Header() {
   return (
-    <header className="flex h-16 items-center justify-end border-b bg-white px-4 shadow dark:bg-[#101a23]">
+    <header className="flex h-16 items-center justify-end border-b bg-white px-4 shadow text-gray-900 dark:bg-[#101a23] dark:text-white">
       <NotificationBell />
     </header>
   )

--- a/app/src/components/NotificationBell.tsx
+++ b/app/src/components/NotificationBell.tsx
@@ -28,7 +28,7 @@ export default function NotificationBell() {
         className="relative rounded-full p-2"
         onClick={() => setOpen(!open)}
       >
-        <Bell className="h-6 w-6 text-white" />
+        <Bell className="h-6 w-6 text-gray-900 dark:text-white" />
         {unreadCount > 0 && (
           <span className="absolute top-0 right-0 flex h-3 w-3 items-center justify-center rounded-full bg-red-600 text-xs text-white">
             {unreadCount}

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -31,12 +31,12 @@ export default function Sidebar({ open = false, onToggle }: SidebarProps) {
   
   return (
     <aside
-      className={`fixed left-0 top-0 z-20 h-full bg-[#101a23] transition-all lg:w-80 ${
+      className={`fixed left-0 top-0 z-20 h-full transition-all lg:w-80 ${
         isOpen ? 'w-80' : 'w-16'
-      }`}
+      } bg-gray-100 text-gray-900 dark:bg-[#101a23] dark:text-white`}
     >
       <div className="flex h-full flex-col">
-        <div className="flex items-center justify-between p-4 text-white">
+        <div className="flex items-center justify-between p-4 text-gray-900 dark:text-white">
           <span className="flex items-center gap-2">
             <Plane className="h-6 w-6" />
             <span className={`${isOpen ? 'block' : 'hidden lg:block'} font-heading text-xl`}>VA Stats</span>
@@ -51,8 +51,8 @@ export default function Sidebar({ open = false, onToggle }: SidebarProps) {
               key={to}
               to={to}
               className={({ isActive }) =>
-                `flex items-center gap-3 rounded-md p-2 text-white hover:bg-[#223649] ${
-                  isActive ? 'bg-[#223649]' : ''
+                `flex items-center gap-3 rounded-md p-2 text-gray-900 hover:bg-gray-200 dark:text-white dark:hover:bg-[#223649] ${
+                  isActive ? 'bg-gray-200 dark:bg-[#223649]' : ''
                 }`
               }
             >
@@ -65,8 +65,8 @@ export default function Sidebar({ open = false, onToggle }: SidebarProps) {
           <NavLink
             to={admin.to}
             className={({ isActive }) =>
-              `flex items-center gap-3 rounded-md p-2 text-white hover:bg-[#223649] ${
-                isActive ? 'bg-[#223649]' : ''
+              `flex items-center gap-3 rounded-md p-2 text-gray-900 hover:bg-gray-200 dark:text-white dark:hover:bg-[#223649] ${
+                isActive ? 'bg-gray-200 dark:bg-[#223649]' : ''
               }`
             }
           >

--- a/app/src/components/ui/button.tsx
+++ b/app/src/components/ui/button.tsx
@@ -8,7 +8,7 @@ type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
 
 const variants: Record<NonNullable<ButtonProps['variant']>, string> = {
   default: 'bg-blue-600 text-white hover:bg-blue-500',
-  outline: 'border border-gray-300 hover:bg-gray-100',
+  outline: 'border border-gray-300 hover:bg-gray-100 dark:border-gray-600 dark:hover:bg-gray-700',
   destructive: 'bg-red-600 text-white hover:bg-red-500',
 }
 

--- a/app/src/components/ui/input.tsx
+++ b/app/src/components/ui/input.tsx
@@ -10,7 +10,7 @@ export const Input = React.forwardRef<HTMLInputElement, InputProps>(
         type={type}
         ref={ref}
         className={cn(
-          'flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500',
+          'flex h-10 w-full rounded-md border border-gray-300 bg-white px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 dark:border-gray-600 dark:bg-gray-700 dark:text-white',
           className,
         )}
         {...props}

--- a/app/src/components/ui/table.tsx
+++ b/app/src/components/ui/table.tsx
@@ -9,7 +9,7 @@ export const Table = forwardRef<HTMLTableElement, HTMLAttributes<HTMLTableElemen
 export function TableHeader({ className, ...props }: HTMLAttributes<HTMLTableSectionElement>) {
   return (
     <thead
-      className={cn('bg-gray-900 text-gray-300 sticky top-0', className)}
+      className={cn('sticky top-0 bg-gray-200 text-gray-700 dark:bg-gray-900 dark:text-gray-300', className)}
       {...props}
     />
   )


### PR DESCRIPTION
## Summary
- add theme-aware body classes
- style sidebar, header, pages and components with dark/light variants
- update form controls and tables for both themes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858858cbae08322a2d7e15e595f5c1a