### PR TITLE
Revamp settings page with profile and ACARS tabs

### DIFF
--- a/app/src/SettingsPage.tsx
+++ b/app/src/SettingsPage.tsx
@@ -1,8 +1,86 @@
-import { useEffect } from 'react'
-import { Switch } from './components'
+import { useState, useEffect } from 'react'
+import { Tabs, Switch, Input, Label, Button } from './components'
 import { useSettings } from './settingsSlice'
+import { useAuth } from './authSlice'
 
-export default function SettingsPage() {
+function ProfileTab() {
+  const { user } = useAuth()
+  const [name, setName] = useState(user?.username ?? '')
+  const [email, setEmail] = useState(user?.email ?? '')
+  const [password, setPassword] = useState('')
+  const handleSave = () => {
+    // Placeholder for saving profile changes
+    console.log('Save profile', { name, email, password })
+  }
+  return (
+    <div className="space-y-4">
+      <div>
+        <Label htmlFor="name">Name</Label>
+        <Input id="name" value={name} onChange={(e) => setName(e.target.value)} />
+      </div>
+      <div>
+        <Label htmlFor="email">Email</Label>
+        <Input id="email" value={email} onChange={(e) => setEmail(e.target.value)} />
+      </div>
+      <div>
+        <Label htmlFor="password">Change Password</Label>
+        <Input
+          id="password"
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+      </div>
+      <Button className="mt-2" onClick={handleSave}>
+        Save Profile
+      </Button>
+    </div>
+  )
+}
+
+function AcarsTab() {
+  const {
+    acarsPollInterval,
+    acarsFormat,
+    acarsLogging,
+    setAcarsPollInterval,
+    setAcarsFormat,
+    setAcarsLogging,
+  } = useSettings()
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <span>ACARS Poll Interval</span>
+        <select
+          value={acarsPollInterval}
+          onChange={(e) => setAcarsPollInterval(parseInt(e.target.value) as 1 | 5 | 10)}
+          className="rounded-md bg-white p-2 text-gray-900 dark:bg-gray-700 dark:text-white"
+        >
+          <option value={1}>1s</option>
+          <option value={5}>5s</option>
+          <option value={10}>10s</option>
+        </select>
+      </div>
+      <div className="flex items-center justify-between">
+        <span>Data Format</span>
+        <select
+          value={acarsFormat}
+          onChange={(e) => setAcarsFormat(e.target.value as 'json' | 'xml')}
+          className="rounded-md bg-white p-2 text-gray-900 dark:bg-gray-700 dark:text-white"
+        >
+          <option value="json">JSON</option>
+          <option value="xml">XML</option>
+        </select>
+      </div>
+      <div className="flex items-center justify-between">
+        <span>Enable Logging</span>
+        <Switch checked={acarsLogging} onChange={setAcarsLogging} className="" />
+      </div>
+    </div>
+  )
+}
+
+function AppTab() {
   const {
     theme,
     distanceUnit,
@@ -11,7 +89,6 @@ export default function SettingsPage() {
     mapStyle,
     notificationsPush,
     notificationsEmail,
-    acarsPollInterval,
     toggleTheme,
     setDistanceUnit,
     setSpeedUnit,
@@ -19,7 +96,6 @@ export default function SettingsPage() {
     setMapStyle,
     setNotificationsPush,
     setNotificationsEmail,
-    setAcarsPollInterval,
   } = useSettings()
 
   useEffect(() => {
@@ -31,18 +107,11 @@ export default function SettingsPage() {
   }, [theme])
 
   return (
-    <div className="max-w-md space-y-4 rounded-lg bg-gray-100 p-6 text-gray-900 dark:bg-gray-800 dark:text-white">
+    <div className="space-y-4">
       <div className="flex items-center justify-between">
         <span>Dark Theme</span>
-        <Switch
-          checked={theme === 'dark'}
-          onChange={() => toggleTheme()}
-          className={`${
-            theme === 'dark' ? 'bg-blue-600' : 'bg-gray-200'
-          } relative inline-flex h-6 w-11 items-center rounded-full`}
-        />
+        <Switch checked={theme === 'dark'} onChange={toggleTheme} className="" />
       </div>
-
       <div className="flex items-center justify-between">
         <span>Distance Unit</span>
         <select
@@ -54,7 +123,6 @@ export default function SettingsPage() {
           <option value="km">Kilometers</option>
         </select>
       </div>
-
       <div className="flex items-center justify-between">
         <span>Speed Unit</span>
         <select
@@ -66,7 +134,6 @@ export default function SettingsPage() {
           <option value="kmh">km/h</option>
         </select>
       </div>
-
       <div className="flex items-center justify-between">
         <span>Altitude Unit</span>
         <select
@@ -78,7 +145,6 @@ export default function SettingsPage() {
           <option value="m">Meters</option>
         </select>
       </div>
-
       <div className="flex items-center justify-between">
         <span>Map Style</span>
         <select
@@ -91,43 +157,27 @@ export default function SettingsPage() {
           <option value="auto">Auto</option>
         </select>
       </div>
-
       <div className="flex items-center justify-between">
         <span>Push Notifications</span>
-        <Switch
-          checked={notificationsPush}
-          onChange={setNotificationsPush}
-          className={`${
-            notificationsPush ? 'bg-blue-600' : 'bg-gray-200'
-          } relative inline-flex h-6 w-11 items-center rounded-full`}
-        />
+        <Switch checked={notificationsPush} onChange={setNotificationsPush} className="" />
       </div>
-
       <div className="flex items-center justify-between">
         <span>Email Notifications</span>
-        <Switch
-          checked={notificationsEmail}
-          onChange={setNotificationsEmail}
-          className={`${
-            notificationsEmail ? 'bg-blue-600' : 'bg-gray-200'
-          } relative inline-flex h-6 w-11 items-center rounded-full`}
-        />
+        <Switch checked={notificationsEmail} onChange={setNotificationsEmail} className="" />
       </div>
+    </div>
+  )
+}
 
-      <div className="flex items-center justify-between">
-        <span>ACARS Poll Interval</span>
-        <select
-          value={acarsPollInterval}
-          onChange={(e) =>
-            setAcarsPollInterval(parseInt(e.target.value) as 1 | 5 | 10)
-          }
-          className="rounded-md bg-white p-2 text-gray-900 dark:bg-gray-700 dark:text-white"
-        >
-          <option value={1}>1s</option>
-          <option value={5}>5s</option>
-          <option value={10}>10s</option>
-        </select>
-      </div>
+export default function SettingsPage() {
+  const tabs = [
+    { value: 'profile', label: 'Profile', content: <ProfileTab /> },
+    { value: 'acars', label: 'ACARS Settings', content: <AcarsTab /> },
+    { value: 'app', label: 'App Settings', content: <AppTab /> },
+  ]
+  return (
+    <div className="max-w-md rounded-lg bg-gray-100 p-6 text-gray-900 dark:bg-gray-800 dark:text-white">
+      <Tabs tabs={tabs} />
     </div>
   )
 }

--- a/app/src/settingsSlice.ts
+++ b/app/src/settingsSlice.ts
@@ -12,6 +12,8 @@ export interface SettingsState {
   notificationsPush: boolean
   notificationsEmail: boolean
   acarsPollInterval: 1 | 5 | 10
+  acarsFormat: 'json' | 'xml'
+  acarsLogging: boolean
 }
 
 const initialState: SettingsState = {
@@ -23,6 +25,8 @@ const initialState: SettingsState = {
   notificationsPush: true,
   notificationsEmail: true,
   acarsPollInterval: 1,
+  acarsFormat: 'json',
+  acarsLogging: false,
 }
 
 const settingsSlice = createSlice({
@@ -56,6 +60,12 @@ const settingsSlice = createSlice({
     setAcarsPollInterval(state, action: PayloadAction<1 | 5 | 10>) {
       state.acarsPollInterval = action.payload
     },
+    setAcarsFormat(state, action: PayloadAction<'json' | 'xml'>) {
+      state.acarsFormat = action.payload
+    },
+    setAcarsLogging(state, action: PayloadAction<boolean>) {
+      state.acarsLogging = action.payload
+    },
   },
 })
 
@@ -69,6 +79,8 @@ export const {
   setNotificationsPush,
   setNotificationsEmail,
   setAcarsPollInterval,
+  setAcarsFormat,
+  setAcarsLogging,
 } = settingsSlice.actions
 export default settingsSlice.reducer
 
@@ -83,6 +95,8 @@ export const selectNotificationsEmail = (state: RootState) =>
   state.settings.notificationsEmail
 export const selectAcarsPollInterval = (state: RootState) =>
   state.settings.acarsPollInterval
+export const selectAcarsFormat = (state: RootState) => state.settings.acarsFormat
+export const selectAcarsLogging = (state: RootState) => state.settings.acarsLogging
 
 export function useSettings() {
   const dispatch = useAppDispatch()
@@ -94,6 +108,8 @@ export function useSettings() {
   const notificationsPush = useAppSelector(selectNotificationsPush)
   const notificationsEmail = useAppSelector(selectNotificationsEmail)
   const acarsPollInterval = useAppSelector(selectAcarsPollInterval)
+  const acarsFormat = useAppSelector(selectAcarsFormat)
+  const acarsLogging = useAppSelector(selectAcarsLogging)
   return {
     theme,
     distanceUnit,
@@ -103,6 +119,8 @@ export function useSettings() {
     notificationsPush,
     notificationsEmail,
     acarsPollInterval,
+    acarsFormat,
+    acarsLogging,
     toggleTheme: () => dispatch(toggleTheme()),
     setTheme: (value: 'light' | 'dark') => dispatch(setTheme(value)),
     setDistanceUnit: (unit: 'nm' | 'km') => dispatch(setDistanceUnit(unit)),
@@ -112,5 +130,7 @@ export function useSettings() {
     setNotificationsPush: (val: boolean) => dispatch(setNotificationsPush(val)),
     setNotificationsEmail: (val: boolean) => dispatch(setNotificationsEmail(val)),
     setAcarsPollInterval: (val: 1 | 5 | 10) => dispatch(setAcarsPollInterval(val)),
+    setAcarsFormat: (val: 'json' | 'xml') => dispatch(setAcarsFormat(val)),
+    setAcarsLogging: (val: boolean) => dispatch(setAcarsLogging(val)),
   }
 }


### PR DESCRIPTION
## Summary
- overhaul `SettingsPage` with Profile, ACARS and App tabs
- add ACARS settings to Redux store

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685886fa02188322beed4f1f45b21a42