### PR TITLE
Fix dark mode color on outline buttons

### DIFF
--- a/app/src/components/ui/button.tsx
+++ b/app/src/components/ui/button.tsx
@@ -8,7 +8,8 @@ type ButtonProps = ButtonHTMLAttributes<HTMLButtonElement> & {
 
 const variants: Record<NonNullable<ButtonProps['variant']>, string> = {
   default: 'bg-blue-600 text-white hover:bg-blue-500',
-  outline: 'border border-gray-300 hover:bg-gray-100 dark:border-gray-600 dark:hover:bg-gray-700',
+  outline:
+    'border border-gray-300 text-gray-900 hover:bg-gray-100 dark:border-gray-600 dark:text-white dark:hover:bg-gray-700',
   destructive: 'bg-red-600 text-white hover:bg-red-500',
 }
 


### PR DESCRIPTION
## Summary
- adjust outline button variant to apply dark text color in dark mode

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858899e6cf8832287efb986f8c631fc