### PR TITLE
Fix title color in light mode

### DIFF
--- a/app/src/components/CommunityHub.tsx
+++ b/app/src/components/CommunityHub.tsx
@@ -39,7 +39,7 @@ export default function CommunityHub() {
   ]
 
   return (
-    <div className="space-y-8 p-6 text-white">
+    <div className="space-y-8 p-6 text-gray-900 dark:text-white">
       <header className="space-y-1">
         <h1 className="font-heading text-3xl">Community Hub</h1>
         <p className="font-body text-[#90adcb]">Latest airline activity and events</p>


### PR DESCRIPTION
## Summary
- make CommunityHub text color adapt to light or dark themes

## Testing
- `npm run verify`


------
https://chatgpt.com/codex/tasks/task_e_68588a949be48322860562d779c8383b