### PR TITLE
Improve tab styling on settings page

### DIFF
--- a/app/src/components/ui/tabs.tsx
+++ b/app/src/components/ui/tabs.tsx
@@ -17,21 +17,23 @@ export function Tabs({ tabs, defaultValue, className }: TabsProps) {
   const [active, setActive] = useState(defaultValue ?? tabs[0]?.value)
   return (
     <div className={className}>
-      <div className="flex border-b mb-2">
-        {tabs.map((t) => (
-          <button
-            key={t.value}
-            onClick={() => setActive(t.value)}
-            className={cn(
-              'px-3 py-2 text-sm',
-              active === t.value
-                ? 'border-b-2 border-blue-600 text-blue-600'
-                : 'text-gray-500 hover:text-gray-700',
-            )}
-          >
-            {t.label}
-          </button>
-        ))}
+      <div className="mb-4 border-b border-gray-300 dark:border-gray-700">
+        <nav className="-mb-px flex space-x-2">
+          {tabs.map((t) => (
+            <button
+              key={t.value}
+              onClick={() => setActive(t.value)}
+              className={cn(
+                'px-4 py-2 text-sm font-medium rounded-t-md',
+                active === t.value
+                  ? 'bg-gray-100 dark:bg-gray-800 border border-gray-300 dark:border-gray-600 border-b-transparent text-blue-600'
+                  : 'border border-transparent text-gray-500 hover:text-gray-700 hover:bg-gray-50 dark:hover:bg-gray-700',
+              )}
+            >
+              {t.label}
+            </button>
+          ))}
+        </nav>
       </div>
       <div>{tabs.find((t) => t.value === active)?.content}</div>
     </div>


### PR DESCRIPTION
## Summary
- improve tab styles so they look like tabs rather than buttons

## Testing
- `npm --prefix app run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68588acc95e883229f0e6c7757781f8a