### PR TITLE
Add persistent chat widget

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -1,7 +1,7 @@
 import { HashRouter, Routes, Route, Navigate, Outlet } from 'react-router-dom'
 import { useState } from 'react'
 import Sidebar from './components/Sidebar'
-import { Header } from './components'
+import { Header, ChatAndNotifications } from './components'
 import LoginScreen from './LoginScreen'
 import ProtectedRoute from './ProtectedRoute'
 import FlightsPage from './FlightsPage'
@@ -26,6 +26,7 @@ function ProtectedLayout() {
           <Outlet />
         </main>
       </div>
+      <ChatAndNotifications />
     </div>
   )
 }

--- a/app/src/components/ChatAndNotifications.tsx
+++ b/app/src/components/ChatAndNotifications.tsx
@@ -56,8 +56,8 @@ export default function ChatAndNotifications() {
           )}
         </button>
       </div>
-      <Dialog open={open} onClose={setOpen} className="fixed inset-y-0 left-0 z-40 flex">
-        <Dialog.Panel className="flex h-full w-[200px] flex-col bg-white shadow-lg dark:bg-[#101a23]">
+      <Dialog open={open} onClose={setOpen} className="fixed inset-y-0 right-0 z-40 flex">
+        <Dialog.Panel className="flex h-full w-72 flex-col bg-white shadow-lg dark:bg-[#101a23]">
           <div className="flex items-center justify-between border-b p-2">
             <Dialog.Title className="font-semibold">Community Chat</Dialog.Title>
             {unread > 0 && (
@@ -66,9 +66,15 @@ export default function ChatAndNotifications() {
               </span>
             )}
           </div>
-          <div ref={messagesRef} className="flex-1 space-y-1 overflow-y-auto p-2 text-sm">
+          <div
+            ref={messagesRef}
+            className="flex-1 space-y-2 overflow-y-auto p-2 text-sm"
+          >
             {messages.map((m, i) => (
-              <div key={i} className="rounded bg-gray-200 p-1 dark:bg-gray-700">
+              <div
+                key={i}
+                className="rounded-lg bg-gray-200 px-3 py-1 dark:bg-gray-700"
+              >
                 {m}
               </div>
             ))}


### PR DESCRIPTION
## Summary
- open chat popout from the right side with larger layout
- mount `ChatAndNotifications` in `ProtectedLayout` so chat is present on all pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68589f1511148322a90a9cc690406916