### PR TITLE
Add maintenance dashboard route

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -10,6 +10,7 @@ import ProfilePage from './ProfilePage'
 import SettingsPage from './SettingsPage'
 import RosterPage from './RosterPage'
 import HomePage from './HomePage'
+import MaintenanceDashboard from './MaintenanceDashboard'
 
 
 function ProtectedLayout() {
@@ -41,6 +42,7 @@ export default function App() {
             <Route index element={<Navigate to="/dashboard" replace />} />
             <Route path="dashboard" element={<HomePage />} />
             <Route path="flights" element={<FlightsPage />} />
+            <Route path="maintenance" element={<MaintenanceDashboard />} />
             <Route path="community" element={<CommunityHub />} />
             <Route path="roster" element={<RosterPage />} />
             <Route path="settings" element={<SettingsPage />} />

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
 import { NavLink, useNavigate } from 'react-router-dom'
-import { Home, Plane, Users, Calendar, Settings, Shield, Menu, LogOut } from 'lucide-react'
+import { Home, Plane, Users, Calendar, Settings, Shield, Menu, LogOut, Wrench } from 'lucide-react'
 import { useState } from 'react'
 import { useAuth } from '../authSlice'
 
@@ -21,6 +21,7 @@ export default function Sidebar({ open = false, onToggle }: SidebarProps) {
   const items = [
     { to: '/', label: 'Home', icon: Home },
     { to: '/flights', label: 'Flights', icon: Plane },
+    { to: '/maintenance', label: 'Maintenance', icon: Wrench },
     { to: '/community', label: 'Community', icon: Users },
     { to: '/roster', label: 'Roster', icon: Calendar },
     { to: '/settings', label: 'Settings', icon: Settings },


### PR DESCRIPTION
## Summary
- include MaintenanceDashboard in routes
- show link to MaintenanceDashboard in sidebar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68589ea56eb88322a23274341d6ea656