### PR TITLE
Add dark mode hook

### DIFF
--- a/app/src/ProfilePage.tsx
+++ b/app/src/ProfilePage.tsx
@@ -1,9 +1,10 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Tab } from '@headlessui/react'
 import { Button, Input, Label, Switch } from './components'
 import { useAuth } from './authSlice'
 import { useSettings } from './settingsSlice'
+import useDarkMode from './hooks/useDarkMode'
 
 export function ProfilePage() {
   const auth = useAuth()
@@ -33,13 +34,7 @@ export function ProfilePage() {
     setAcarsLogging,
   } = useSettings()
 
-  useEffect(() => {
-    if (theme === 'dark') {
-      document.documentElement.classList.add('dark')
-    } else {
-      document.documentElement.classList.remove('dark')
-    }
-  }, [theme])
+  useDarkMode(theme)
 
   const [name, setName] = useState(user.username)
   const [email, setEmail] = useState(user.email)

--- a/app/src/SettingsPage.tsx
+++ b/app/src/SettingsPage.tsx
@@ -1,7 +1,8 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { Tabs, Switch, Input, Label, Button, Select } from './components'
 import { useSettings } from './settingsSlice'
 import { useAuth } from './authSlice'
+import useDarkMode from './hooks/useDarkMode'
 
 const acarsPollOptions = [
   { value: 1, label: '1s' },
@@ -123,13 +124,7 @@ function AppTab() {
     setNotificationsEmail,
   } = useSettings()
 
-  useEffect(() => {
-    if (theme === 'dark') {
-      document.documentElement.classList.add('dark')
-    } else {
-      document.documentElement.classList.remove('dark')
-    }
-  }, [theme])
+  useDarkMode(theme)
 
   return (
     <div className="space-y-4">

--- a/app/src/SettingsSection.tsx
+++ b/app/src/SettingsSection.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import useDarkMode from './hooks/useDarkMode'
 import { Switch, Select } from './components'
 import { useSettings } from './settingsSlice'
 
@@ -29,13 +29,7 @@ export default function SettingsSection() {
     setAltitudeUnit,
   } = useSettings()
 
-  useEffect(() => {
-    if (theme === 'dark') {
-      document.documentElement.classList.add('dark')
-    } else {
-      document.documentElement.classList.remove('dark')
-    }
-  }, [theme])
+  useDarkMode(theme)
 
   return (
     <div className="w-full max-w-sm space-y-4 rounded-lg bg-gray-100 p-6 text-gray-900 dark:bg-gray-800 dark:text-white">

--- a/app/src/hooks/useDarkMode.ts
+++ b/app/src/hooks/useDarkMode.ts
@@ -1,0 +1,11 @@
+import { useEffect } from 'react'
+
+export default function useDarkMode(theme: 'light' | 'dark') {
+  useEffect(() => {
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark')
+    } else {
+      document.documentElement.classList.remove('dark')
+    }
+  }, [theme])
+}


### PR DESCRIPTION
## Summary
- add `useDarkMode` hook
- use `useDarkMode` in profile and settings pages

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858a5bff2ac83228e5538b0fd772c04