### PR TITLE
Add localStorage persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,8 @@ npm run dist
 
 The compiled files will be produced using `electron-builder`.
 
+## Persistence
+
+User authentication and settings are saved to `localStorage` so state is
+restored the next time the application starts.
+

--- a/app/src/store.ts
+++ b/app/src/store.ts
@@ -1,4 +1,4 @@
-import { configureStore } from '@reduxjs/toolkit'
+import { configureStore, combineReducers } from '@reduxjs/toolkit'
 import authReducer from './authSlice'
 import settingsReducer from './settingsSlice'
 import acarsReducer from './acarsSlice'
@@ -9,20 +9,50 @@ import notificationsReducer from './notificationsSlice'
 import rosterReducer from './rosterSlice'
 import dashboardReducer from './dashboardSlice'
 
-export const store = configureStore({
-  reducer: {
-    auth: authReducer,
-    settings: settingsReducer,
-    acars: acarsReducer,
-    logbook: logbookReducer,
-    fleet: fleetReducer,
-    flights: flightsReducer,
-    notifications: notificationsReducer,
-    roster: rosterReducer,
-    dashboard: dashboardReducer,
-  },
-  middleware: (getDefaultMiddleware) => getDefaultMiddleware(),
+const STORAGE_KEY = 'va-stats'
+
+function loadState() {
+  if (typeof localStorage === 'undefined') return undefined
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    return raw ? JSON.parse(raw) : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function saveState(state: RootState) {
+  if (typeof localStorage === 'undefined') return
+  try {
+    const { auth, settings } = state
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({ auth, settings }),
+    )
+  } catch {
+    // ignore write errors
+  }
+}
+
+const reducer = combineReducers({
+  auth: authReducer,
+  settings: settingsReducer,
+  acars: acarsReducer,
+  logbook: logbookReducer,
+  fleet: fleetReducer,
+  flights: flightsReducer,
+  notifications: notificationsReducer,
+  roster: rosterReducer,
+  dashboard: dashboardReducer,
 })
+
+export const store = configureStore({
+  reducer,
+  middleware: (getDefaultMiddleware) => getDefaultMiddleware(),
+  preloadedState: loadState() as any,
+})
+
+store.subscribe(() => saveState(store.getState()))
 
 export type RootState = ReturnType<typeof store.getState>
 export type AppDispatch = typeof store.dispatch


### PR DESCRIPTION
## Summary
- persist auth and settings in localStorage
- hydrate state from saved values
- document persistence behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858a5df794883229c193f5986e70d99