### PR TITLE
Expose preload API and store profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,3 +32,13 @@ npm run dist
 
 The compiled files will be produced using `electron-builder`.
 
+
+## Renderer API
+
+The preload script exposes a small API under `window.electron`:
+
+- `openExternal(url)` – open a URL in the system browser.
+- `saveData(key, value)` – persist JSON data under the given key.
+- `loadData(key)` – retrieve previously saved data.
+
+Both `saveData` and `loadData` return promises.

--- a/app/src/ProfilePage.tsx
+++ b/app/src/ProfilePage.tsx
@@ -45,8 +45,17 @@ export function ProfilePage() {
   const [email, setEmail] = useState(user.email)
   const [password, setPassword] = useState('')
 
+  useEffect(() => {
+    window.electron.loadData('profile').then((data: any) => {
+      if (data) {
+        setName((data as any).name ?? user.username)
+        setEmail((data as any).email ?? user.email)
+      }
+    })
+  }, [])
+
   const handleSave = () => {
-    console.log('Save profile', { name, email, password })
+    window.electron.saveData('profile', { name, email })
   }
 
   const handleLogout = () => {

--- a/app/src/SettingsPage.tsx
+++ b/app/src/SettingsPage.tsx
@@ -40,9 +40,16 @@ function ProfileTab() {
   const [name, setName] = useState(user?.username ?? '')
   const [email, setEmail] = useState(user?.email ?? '')
   const [password, setPassword] = useState('')
+  useEffect(() => {
+    window.electron.loadData('profile').then((data: any) => {
+      if (data) {
+        setName((data as any).name ?? user?.username ?? '')
+        setEmail((data as any).email ?? user?.email ?? '')
+      }
+    })
+  }, [])
   const handleSave = () => {
-    // Placeholder for saving profile changes
-    console.log('Save profile', { name, email, password })
+    window.electron.saveData('profile', { name, email })
   }
   return (
     <div className="space-y-4">

--- a/app/src/electron-api.d.ts
+++ b/app/src/electron-api.d.ts
@@ -1,0 +1,13 @@
+export interface ElectronAPI {
+  openExternal: (url: string) => Promise<void>
+  saveData: (key: string, value: unknown) => Promise<void>
+  loadData: (key: string) => Promise<unknown>
+}
+
+declare global {
+  interface Window {
+    electron: ElectronAPI
+  }
+}
+
+export {}

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,5 +1,8 @@
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, ipcMain, shell } = require('electron');
 const path = require('path');
+const fs = require('fs').promises;
+
+const dataFile = path.join(app.getPath('userData'), 'user-data.json');
 
 const isDev = !app.isPackaged;
 
@@ -22,6 +25,33 @@ function createWindow () {
 }
 
 app.whenReady().then(createWindow);
+
+ipcMain.handle('open-external', (event, url) => {
+  if (typeof url === 'string') {
+    shell.openExternal(url);
+  }
+});
+
+ipcMain.handle('save-data', async (event, key, value) => {
+  if (!key) return;
+  let data = {};
+  try {
+    const raw = await fs.readFile(dataFile, 'utf8');
+    data = JSON.parse(raw);
+  } catch (_) {}
+  data[key] = value;
+  await fs.writeFile(dataFile, JSON.stringify(data, null, 2));
+});
+
+ipcMain.handle('load-data', async (event, key) => {
+  try {
+    const raw = await fs.readFile(dataFile, 'utf8');
+    const data = JSON.parse(raw);
+    return key ? data[key] : data;
+  } catch (_) {
+    return null;
+  }
+});
 
 app.on('activate', () => {
   if (BrowserWindow.getAllWindows().length === 0) {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,3 +1,7 @@
-const { contextBridge } = require('electron');
+const { contextBridge, ipcRenderer } = require('electron');
 
-contextBridge.exposeInMainWorld('electron', {});
+contextBridge.exposeInMainWorld('electron', {
+  openExternal: (url) => ipcRenderer.invoke('open-external', url),
+  saveData: (key, value) => ipcRenderer.invoke('save-data', key, value),
+  loadData: (key) => ipcRenderer.invoke('load-data', key),
+});


### PR DESCRIPTION
## Summary
- expose `openExternal`, `saveData`, and `loadData` in the preload script
- handle new IPC events in the Electron main process
- store profile info from `SettingsPage` and `ProfilePage` via the new API
- document the `window.electron` API

## Testing
- `npm run verify`

------
https://chatgpt.com/codex/tasks/task_e_6858a5cedb908322a373eb7eb22a7a12