### PR TITLE
Move Redux hooks to dedicated files

### DIFF
--- a/app/src/FleetPage.tsx
+++ b/app/src/FleetPage.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Button, Dialog, Input, Label, Select } from './components'
-import { useFleet } from './fleetSlice'
+import { useFleet } from './fleetHooks'
 
 type Status = 'OK' | 'Needs Maintenance'
 

--- a/app/src/FlightsPage.tsx
+++ b/app/src/FlightsPage.tsx
@@ -14,15 +14,8 @@ import {
   verticalListSortingStrategy,
 } from '@dnd-kit/sortable'
 import { CSS } from '@dnd-kit/utilities'
-import { useAppDispatch, useAppSelector } from './storeHooks'
-import {
-  selectFlights,
-  selectSort,
-  reorderFlights,
-  toggleSort,
-  type Flight,
-  type SortField,
-} from './flightsSlice'
+import type { Flight, SortField } from './flightsSlice'
+import { useFlights } from './flightsHooks'
 import { Button, Input } from './components'
 
 function SortableRow({ flight }: { flight: Flight }) {
@@ -63,9 +56,7 @@ function SortableRow({ flight }: { flight: Flight }) {
 }
 
 export default function FlightsPage() {
-  const flights = useAppSelector(selectFlights)
-  const sort = useAppSelector(selectSort)
-  const dispatch = useAppDispatch()
+  const { flights, sort, reorder, toggleSort } = useFlights()
   const [filter, setFilter] = useState('')
 
   const filtered = useMemo(() => {
@@ -82,7 +73,7 @@ export default function FlightsPage() {
   const sensors = useSensors(useSensor(PointerSensor))
 
   function handleSort(field: SortField) {
-    dispatch(toggleSort(field))
+    toggleSort(field)
   }
 
   function handleDragEnd(event: DragEndEvent) {
@@ -90,7 +81,7 @@ export default function FlightsPage() {
     if (!over) return
     const from = flights.findIndex((f) => f.id === active.id)
     const to = flights.findIndex((f) => f.id === over.id)
-    if (from !== to) dispatch(reorderFlights({ from, to }))
+    if (from !== to) reorder(from, to)
   }
 
   return (

--- a/app/src/HomePage.tsx
+++ b/app/src/HomePage.tsx
@@ -1,5 +1,5 @@
 import { Calendar } from 'lucide-react'
-import { useDashboard } from './dashboardSlice'
+import { useDashboard } from './dashboardHooks'
 
 export default function HomePage() {
   const {

--- a/app/src/LoginScreen.tsx
+++ b/app/src/LoginScreen.tsx
@@ -1,7 +1,7 @@
 import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Button, Input, Label, Tabs } from './components'
-import { useAuth } from './authSlice'
+import { useAuth } from './authHooks'
 
 export function LoginScreen() {
   const [username, setUsername] = useState('')

--- a/app/src/ProfilePage.tsx
+++ b/app/src/ProfilePage.tsx
@@ -2,8 +2,8 @@ import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { Tab } from '@headlessui/react'
 import { Button, Input, Label, Switch } from './components'
-import { useAuth } from './authSlice'
-import { useSettings } from './settingsSlice'
+import { useAuth } from './authHooks'
+import { useSettings } from './settingsHooks'
 
 export function ProfilePage() {
   const auth = useAuth()

--- a/app/src/RosterPage.tsx
+++ b/app/src/RosterPage.tsx
@@ -1,4 +1,4 @@
-import { useRoster } from './rosterSlice'
+import { useRoster } from './rosterHooks'
 import PilotCard from './PilotCard'
 
 export default function RosterPage() {

--- a/app/src/SettingsPage.tsx
+++ b/app/src/SettingsPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react'
 import { Tabs, Switch, Input, Label, Button, Select } from './components'
-import { useSettings } from './settingsSlice'
-import { useAuth } from './authSlice'
+import { useSettings } from './settingsHooks'
+import { useAuth } from './authHooks'
 
 const acarsPollOptions = [
   { value: 1, label: '1s' },

--- a/app/src/SettingsSection.tsx
+++ b/app/src/SettingsSection.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react'
 import { Switch, Select } from './components'
-import { useSettings } from './settingsSlice'
+import { useSettings } from './settingsHooks'
 
 const distanceOptions = [
   { value: 'nm', label: 'Nautical Miles' },

--- a/app/src/acarsHooks.ts
+++ b/app/src/acarsHooks.ts
@@ -1,0 +1,23 @@
+import { useAppDispatch, useAppSelector } from './storeHooks'
+import {
+  startFlight,
+  endFlight,
+  startAcarsFeed,
+  stopAcarsFeed,
+  selectIsFlying,
+  selectData,
+} from './acarsSlice'
+
+export function useAcars() {
+  const dispatch = useAppDispatch()
+  const isFlying = useAppSelector(selectIsFlying)
+  const data = useAppSelector(selectData)
+  return {
+    isFlying,
+    data,
+    startFlight: () => dispatch(startFlight()),
+    endFlight: () => dispatch(endFlight()),
+    startAcarsFeed: () => dispatch(startAcarsFeed()),
+    stopAcarsFeed: () => dispatch(stopAcarsFeed()),
+  }
+}

--- a/app/src/acarsSlice.ts
+++ b/app/src/acarsSlice.ts
@@ -1,6 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit'
 import type { PayloadAction } from '@reduxjs/toolkit'
-import { useAppDispatch, useAppSelector } from './storeHooks'
 import type { AppDispatch, RootState } from './store'
 
 export interface DataPoint {
@@ -70,16 +69,3 @@ export const stopAcarsFeed = () => () => {
   }
 }
 
-export function useAcars() {
-  const dispatch = useAppDispatch()
-  const isFlying = useAppSelector(selectIsFlying)
-  const data = useAppSelector(selectData)
-  return {
-    isFlying,
-    data,
-    startFlight: () => dispatch(startFlight()),
-    endFlight: () => dispatch(endFlight()),
-    startAcarsFeed: () => dispatch(startAcarsFeed()),
-    stopAcarsFeed: () => dispatch(stopAcarsFeed()),
-  }
-}

--- a/app/src/authHooks.ts
+++ b/app/src/authHooks.ts
@@ -1,0 +1,14 @@
+import { useAppDispatch, useAppSelector } from './storeHooks'
+import { login, logout, selectIsAuthenticated, selectUser } from './authSlice'
+
+export function useAuth() {
+  const dispatch = useAppDispatch()
+  const isAuthenticated = useAppSelector(selectIsAuthenticated)
+  const user = useAppSelector(selectUser)
+  return {
+    isAuthenticated,
+    user,
+    login: () => dispatch(login()),
+    logout: () => dispatch(logout()),
+  }
+}

--- a/app/src/authSlice.ts
+++ b/app/src/authSlice.ts
@@ -1,5 +1,4 @@
 import { createSlice } from '@reduxjs/toolkit'
-import { useAppDispatch, useAppSelector } from './storeHooks'
 import type { RootState } from './store'
 
 export interface AuthState {
@@ -37,14 +36,3 @@ export const selectIsAuthenticated = (state: RootState) =>
   state.auth.isAuthenticated
 export const selectUser = (state: RootState) => state.auth.user
 
-export function useAuth() {
-  const dispatch = useAppDispatch()
-  const isAuthenticated = useAppSelector(selectIsAuthenticated)
-  const user = useAppSelector(selectUser)
-  return {
-    isAuthenticated,
-    user,
-    login: () => dispatch(login()),
-    logout: () => dispatch(logout()),
-  }
-}

--- a/app/src/components/ChatAndNotifications.tsx
+++ b/app/src/components/ChatAndNotifications.tsx
@@ -4,7 +4,7 @@ import { MessageCircle } from 'lucide-react'
 import toast, { Toaster } from 'react-hot-toast'
 import { selectNotifications, clearNotification } from '../notificationsSlice'
 import { useAppDispatch, useAppSelector } from '../storeHooks'
-import { useAuth } from '../authSlice'
+import { useAuth } from '../authHooks'
 
 export default function ChatAndNotifications() {
   const [open, setOpen] = useState(false)

--- a/app/src/components/Header.tsx
+++ b/app/src/components/Header.tsx
@@ -1,6 +1,6 @@
 import NotificationBell from './NotificationBell'
-import { useAuth } from '../authSlice'
-import { useAcars } from '../acarsSlice'
+import { useAuth } from '../authHooks'
+import { useAcars } from '../acarsHooks'
 
 export default function Header() {
   const { user } = useAuth()

--- a/app/src/components/NotificationBell.tsx
+++ b/app/src/components/NotificationBell.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react'
 import { Bell } from 'lucide-react'
-import { useNotifications } from '../notificationsSlice'
+import { useNotifications } from '../notificationsHooks'
 
 export default function NotificationBell() {
   const { unreadCount } = useNotifications()

--- a/app/src/components/Sidebar.tsx
+++ b/app/src/components/Sidebar.tsx
@@ -1,7 +1,7 @@
 import { NavLink, useNavigate } from 'react-router-dom'
 import { Home, Plane, Users, Calendar, Settings, Shield, Menu, LogOut, Wrench } from 'lucide-react'
 import { useState } from 'react'
-import { useAuth } from '../authSlice'
+import { useAuth } from '../authHooks'
 
 interface SidebarProps {
   open?: boolean

--- a/app/src/dashboardHooks.ts
+++ b/app/src/dashboardHooks.ts
@@ -1,0 +1,6 @@
+import { useAppSelector } from './storeHooks'
+import { selectDashboard } from './dashboardSlice'
+
+export function useDashboard() {
+  return useAppSelector(selectDashboard)
+}

--- a/app/src/dashboardSlice.ts
+++ b/app/src/dashboardSlice.ts
@@ -1,5 +1,4 @@
 import { createSlice } from '@reduxjs/toolkit'
-import { useAppSelector } from './storeHooks'
 import type { RootState } from './store'
 
 export interface Event {
@@ -52,6 +51,3 @@ export default dashboardSlice.reducer
 
 export const selectDashboard = (state: RootState) => state.dashboard
 
-export function useDashboard() {
-  return useAppSelector(selectDashboard)
-}

--- a/app/src/fleetHooks.ts
+++ b/app/src/fleetHooks.ts
@@ -1,0 +1,12 @@
+import { useAppDispatch, useAppSelector } from './storeHooks'
+import { addAircraft, markMaintained, selectFleet, type Aircraft } from './fleetSlice'
+
+export function useFleet() {
+  const dispatch = useAppDispatch()
+  const aircraft = useAppSelector(selectFleet)
+  return {
+    aircraft,
+    addAircraft: (a: Aircraft) => dispatch(addAircraft(a)),
+    markMaintained: (tail: string) => dispatch(markMaintained(tail)),
+  }
+}

--- a/app/src/fleetSlice.ts
+++ b/app/src/fleetSlice.ts
@@ -1,6 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit'
 import type { PayloadAction } from '@reduxjs/toolkit'
-import { useAppDispatch, useAppSelector } from './storeHooks'
 import type { RootState } from './store'
 
 export interface Aircraft {
@@ -36,12 +35,3 @@ export default fleetSlice.reducer
 
 export const selectFleet = (state: RootState) => state.fleet
 
-export function useFleet() {
-  const dispatch = useAppDispatch()
-  const aircraft = useAppSelector(selectFleet)
-  return {
-    aircraft,
-    addAircraft: (a: Aircraft) => dispatch(addAircraft(a)),
-    markMaintained: (tail: string) => dispatch(markMaintained(tail)),
-  }
-}

--- a/app/src/flightsHooks.ts
+++ b/app/src/flightsHooks.ts
@@ -1,0 +1,21 @@
+import { useAppDispatch, useAppSelector } from './storeHooks'
+import {
+  reorderFlights,
+  toggleSort,
+  selectFlights,
+  selectSort,
+  type SortField,
+} from './flightsSlice'
+
+export function useFlights() {
+  const dispatch = useAppDispatch()
+  const flights = useAppSelector(selectFlights)
+  const sort = useAppSelector(selectSort)
+  return {
+    flights,
+    sort,
+    reorder: (from: number, to: number) =>
+      dispatch(reorderFlights({ from, to })),
+    toggleSort: (field: SortField) => dispatch(toggleSort(field)),
+  }
+}

--- a/app/src/flightsSlice.ts
+++ b/app/src/flightsSlice.ts
@@ -1,6 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit'
 import type { PayloadAction } from '@reduxjs/toolkit'
-import { useAppDispatch, useAppSelector } from './storeHooks'
 import type { RootState } from './store'
 
 export interface Flight {
@@ -72,15 +71,3 @@ export const selectFlights = (state: RootState) => state.flights.list
 
 export const selectSort = (state: RootState) => state.flights.sort
 
-export function useFlights() {
-  const dispatch = useAppDispatch()
-  const flights = useAppSelector(selectFlights)
-  const sort = useAppSelector(selectSort)
-  return {
-    flights,
-    sort,
-    reorder: (from: number, to: number) =>
-      dispatch(reorderFlights({ from, to })),
-    toggleSort: (field: SortField) => dispatch(toggleSort(field)),
-  }
-}

--- a/app/src/logbookHooks.ts
+++ b/app/src/logbookHooks.ts
@@ -1,0 +1,6 @@
+import { useAppSelector } from './storeHooks'
+import { selectLogbook } from './logbookSlice'
+
+export function useLogbook() {
+  return useAppSelector(selectLogbook)
+}

--- a/app/src/logbookSlice.ts
+++ b/app/src/logbookSlice.ts
@@ -1,5 +1,4 @@
 import { createSlice } from '@reduxjs/toolkit'
-import { useAppSelector } from './storeHooks'
 import type { RootState } from './store'
 
 export interface LogEntry {
@@ -27,6 +26,3 @@ export default logbookSlice.reducer
 
 export const selectLogbook = (state: RootState) => state.logbook
 
-export function useLogbook() {
-  return useAppSelector(selectLogbook)
-}

--- a/app/src/notificationsHooks.ts
+++ b/app/src/notificationsHooks.ts
@@ -1,0 +1,24 @@
+import { useAppDispatch, useAppSelector } from './storeHooks'
+import {
+  setUnreadCount,
+  markAllRead,
+  addNotification,
+  clearNotification,
+  selectUnreadCount,
+  selectNotifications,
+} from './notificationsSlice'
+
+export function useNotifications() {
+  const dispatch = useAppDispatch()
+  const unreadCount = useAppSelector(selectUnreadCount)
+  const notifications = useAppSelector(selectNotifications)
+
+  return {
+    unreadCount,
+    setUnreadCount: (count: number) => dispatch(setUnreadCount(count)),
+    markAllRead: () => dispatch(markAllRead()),
+    addNotification: (msg: string) => dispatch(addNotification(msg)),
+    clearNotification: (id: number) => dispatch(clearNotification(id)),
+    notifications,
+  }
+}

--- a/app/src/notificationsSlice.ts
+++ b/app/src/notificationsSlice.ts
@@ -1,6 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit'
 import type { PayloadAction } from '@reduxjs/toolkit'
-import { useAppDispatch, useAppSelector } from './storeHooks'
 import type { RootState } from './store'
 
 export interface ToastNotification {
@@ -46,17 +45,3 @@ export const selectUnreadCount = (state: RootState) =>
 export const selectNotifications = (state: RootState) =>
   state.notifications.notifications
 
-export function useNotifications() {
-  const dispatch = useAppDispatch()
-  const unreadCount = useAppSelector(selectUnreadCount)
-  const notifications = useAppSelector(selectNotifications)
-
-  return {
-    unreadCount,
-    setUnreadCount: (count: number) => dispatch(setUnreadCount(count)),
-    markAllRead: () => dispatch(markAllRead()),
-    addNotification: (msg: string) => dispatch(addNotification(msg)),
-    clearNotification: (id: number) => dispatch(clearNotification(id)),
-    notifications,
-  }
-}

--- a/app/src/rosterHooks.ts
+++ b/app/src/rosterHooks.ts
@@ -1,0 +1,6 @@
+import { useAppSelector } from './storeHooks'
+import { selectRoster } from './rosterSlice'
+
+export function useRoster() {
+  return useAppSelector(selectRoster)
+}

--- a/app/src/rosterSlice.ts
+++ b/app/src/rosterSlice.ts
@@ -1,5 +1,4 @@
 import { createSlice } from '@reduxjs/toolkit'
-import { useAppSelector } from './storeHooks'
 import type { RootState } from './store'
 
 export interface Pilot {
@@ -44,6 +43,3 @@ export default rosterSlice.reducer
 
 export const selectRoster = (state: RootState) => state.roster
 
-export function useRoster() {
-  return useAppSelector(selectRoster)
-}

--- a/app/src/settingsHooks.ts
+++ b/app/src/settingsHooks.ts
@@ -1,0 +1,61 @@
+import { useAppDispatch, useAppSelector } from './storeHooks'
+import {
+  toggleTheme,
+  setTheme,
+  setDistanceUnit,
+  setSpeedUnit,
+  setAltitudeUnit,
+  setMapStyle,
+  setNotificationsPush,
+  setNotificationsEmail,
+  setAcarsPollInterval,
+  setAcarsFormat,
+  setAcarsLogging,
+  selectTheme,
+  selectDistanceUnit,
+  selectSpeedUnit,
+  selectAltitudeUnit,
+  selectMapStyle,
+  selectNotificationsPush,
+  selectNotificationsEmail,
+  selectAcarsPollInterval,
+  selectAcarsFormat,
+  selectAcarsLogging,
+} from './settingsSlice'
+
+export function useSettings() {
+  const dispatch = useAppDispatch()
+  const theme = useAppSelector(selectTheme)
+  const distanceUnit = useAppSelector(selectDistanceUnit)
+  const speedUnit = useAppSelector(selectSpeedUnit)
+  const altitudeUnit = useAppSelector(selectAltitudeUnit)
+  const mapStyle = useAppSelector(selectMapStyle)
+  const notificationsPush = useAppSelector(selectNotificationsPush)
+  const notificationsEmail = useAppSelector(selectNotificationsEmail)
+  const acarsPollInterval = useAppSelector(selectAcarsPollInterval)
+  const acarsFormat = useAppSelector(selectAcarsFormat)
+  const acarsLogging = useAppSelector(selectAcarsLogging)
+  return {
+    theme,
+    distanceUnit,
+    speedUnit,
+    altitudeUnit,
+    mapStyle,
+    notificationsPush,
+    notificationsEmail,
+    acarsPollInterval,
+    acarsFormat,
+    acarsLogging,
+    toggleTheme: () => dispatch(toggleTheme()),
+    setTheme: (value: 'light' | 'dark') => dispatch(setTheme(value)),
+    setDistanceUnit: (unit: 'nm' | 'km') => dispatch(setDistanceUnit(unit)),
+    setSpeedUnit: (unit: 'kt' | 'kmh') => dispatch(setSpeedUnit(unit)),
+    setAltitudeUnit: (unit: 'ft' | 'm') => dispatch(setAltitudeUnit(unit)),
+    setMapStyle: (style: 'day' | 'night' | 'auto') => dispatch(setMapStyle(style)),
+    setNotificationsPush: (val: boolean) => dispatch(setNotificationsPush(val)),
+    setNotificationsEmail: (val: boolean) => dispatch(setNotificationsEmail(val)),
+    setAcarsPollInterval: (val: 1 | 5 | 10) => dispatch(setAcarsPollInterval(val)),
+    setAcarsFormat: (val: 'json' | 'xml') => dispatch(setAcarsFormat(val)),
+    setAcarsLogging: (val: boolean) => dispatch(setAcarsLogging(val)),
+  }
+}

--- a/app/src/settingsSlice.ts
+++ b/app/src/settingsSlice.ts
@@ -1,6 +1,5 @@
 import { createSlice } from '@reduxjs/toolkit'
 import type { PayloadAction } from '@reduxjs/toolkit'
-import { useAppDispatch, useAppSelector } from './storeHooks'
 import type { RootState } from './store'
 
 export interface SettingsState {
@@ -98,39 +97,3 @@ export const selectAcarsPollInterval = (state: RootState) =>
 export const selectAcarsFormat = (state: RootState) => state.settings.acarsFormat
 export const selectAcarsLogging = (state: RootState) => state.settings.acarsLogging
 
-export function useSettings() {
-  const dispatch = useAppDispatch()
-  const theme = useAppSelector(selectTheme)
-  const distanceUnit = useAppSelector(selectDistanceUnit)
-  const speedUnit = useAppSelector(selectSpeedUnit)
-  const altitudeUnit = useAppSelector(selectAltitudeUnit)
-  const mapStyle = useAppSelector(selectMapStyle)
-  const notificationsPush = useAppSelector(selectNotificationsPush)
-  const notificationsEmail = useAppSelector(selectNotificationsEmail)
-  const acarsPollInterval = useAppSelector(selectAcarsPollInterval)
-  const acarsFormat = useAppSelector(selectAcarsFormat)
-  const acarsLogging = useAppSelector(selectAcarsLogging)
-  return {
-    theme,
-    distanceUnit,
-    speedUnit,
-    altitudeUnit,
-    mapStyle,
-    notificationsPush,
-    notificationsEmail,
-    acarsPollInterval,
-    acarsFormat,
-    acarsLogging,
-    toggleTheme: () => dispatch(toggleTheme()),
-    setTheme: (value: 'light' | 'dark') => dispatch(setTheme(value)),
-    setDistanceUnit: (unit: 'nm' | 'km') => dispatch(setDistanceUnit(unit)),
-    setSpeedUnit: (unit: 'kt' | 'kmh') => dispatch(setSpeedUnit(unit)),
-    setAltitudeUnit: (unit: 'ft' | 'm') => dispatch(setAltitudeUnit(unit)),
-    setMapStyle: (style: 'day' | 'night' | 'auto') => dispatch(setMapStyle(style)),
-    setNotificationsPush: (val: boolean) => dispatch(setNotificationsPush(val)),
-    setNotificationsEmail: (val: boolean) => dispatch(setNotificationsEmail(val)),
-    setAcarsPollInterval: (val: 1 | 5 | 10) => dispatch(setAcarsPollInterval(val)),
-    setAcarsFormat: (val: 'json' | 'xml') => dispatch(setAcarsFormat(val)),
-    setAcarsLogging: (val: boolean) => dispatch(setAcarsLogging(val)),
-  }
-}


### PR DESCRIPTION
## Summary
- factor hooks into new `*Hooks.ts` modules
- import hooks from new modules across the app
- keep reducers and selectors in existing slice files

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858a60eb4a883229054eaa3b2dd9269