### PR TITLE
Expose preload API for persistence and openExternal

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,21 @@ The compiled files will be produced using `electron-builder`.
 
 ## Persistence
 
-User authentication and settings are saved to `localStorage` so state is
-restored the next time the application starts.
+User authentication and settings are saved using a small persistence API
+exposed by the Electron preload script. When running in a browser, the
+application falls back to `localStorage`.
+
+## Renderer API
+
+The preload script exposes an `electron` object on `window` with the
+following methods:
+
+```ts
+window.electron.openExternal(url: string): Promise<void>
+window.electron.loadState(): any
+window.electron.saveState(data: any): void
+```
+
+`openExternal` opens a URL in the default browser, while `loadState` and
+`saveState` read and write a JSON file in Electron's user data directory.
 

--- a/app/src/store.ts
+++ b/app/src/store.ts
@@ -12,6 +12,10 @@ import dashboardReducer from './dashboardSlice'
 const STORAGE_KEY = 'va-stats'
 
 function loadState() {
+  const api: any = (window as any).electron
+  if (api?.loadState) {
+    return api.loadState() || undefined
+  }
   if (typeof localStorage === 'undefined') return undefined
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
@@ -22,9 +26,13 @@ function loadState() {
 }
 
 function saveState(state: RootState) {
+  const { auth, settings } = state
+  const api: any = (window as any).electron
+  if (api?.saveState) {
+    api.saveState({ auth, settings })
+  }
   if (typeof localStorage === 'undefined') return
   try {
-    const { auth, settings } = state
     localStorage.setItem(
       STORAGE_KEY,
       JSON.stringify({ auth, settings }),

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,7 +1,27 @@
-const { app, BrowserWindow } = require('electron');
+const { app, BrowserWindow, ipcMain, shell } = require('electron');
 const path = require('path');
+const fs = require('fs');
 
 const isDev = !app.isPackaged;
+
+const stateFile = path.join(app.getPath('userData'), 'state.json');
+
+ipcMain.on('save-state', (_, state) => {
+  try {
+    fs.writeFileSync(stateFile, JSON.stringify(state));
+  } catch {}
+});
+
+ipcMain.on('load-state', (event) => {
+  try {
+    const raw = fs.readFileSync(stateFile, 'utf8');
+    event.returnValue = JSON.parse(raw);
+  } catch {
+    event.returnValue = undefined;
+  }
+});
+
+ipcMain.handle('open-external', (_, url) => shell.openExternal(url));
 
 function createWindow () {
   const win = new BrowserWindow({

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,3 +1,7 @@
-const { contextBridge } = require('electron');
+const { contextBridge, ipcRenderer } = require('electron');
 
-contextBridge.exposeInMainWorld('electron', {});
+contextBridge.exposeInMainWorld('electron', {
+  openExternal: (url) => ipcRenderer.invoke('open-external', url),
+  loadState: () => ipcRenderer.sendSync('load-state'),
+  saveState: (data) => ipcRenderer.send('save-state', data),
+});


### PR DESCRIPTION
## Summary
- expose `openExternal`, `loadState`, and `saveState` via `contextBridge`
- handle persistence IPC in `main.js`
- use the new API from the Redux store
- document the preload API

## Testing
- `npm test`
- `npm run verify`


------
https://chatgpt.com/codex/tasks/task_e_6858bdec98bc83229c74be91539b6626