### PR TITLE
Add preload db API

### DIFF
--- a/packages/main/preload.ts
+++ b/packages/main/preload.ts
@@ -1,0 +1,12 @@
+import { contextBridge, ipcRenderer } from 'electron';
+
+contextBridge.exposeInMainWorld('api', {
+  db: {
+    getPilots:      () => ipcRenderer.invoke('db:getPilots'),
+    getAircraft:    () => ipcRenderer.invoke('db:getAircraft'),
+    getFlights:     () => ipcRenderer.invoke('db:getFlights'),
+    getEvents:      () => ipcRenderer.invoke('db:getEvents'),
+    getNotifications: () => ipcRenderer.invoke('db:getNotifications'),
+    getAcarsLogs:   (flightId: number) => ipcRenderer.invoke('db:getAcarsLogs', flightId),
+  }
+});


### PR DESCRIPTION
## Summary
- expose database IPC methods on `window.api.db`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b3b9566108322915d0255bb44f885