### PR TITLE
Add electron-log and use it across main process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
-        "electron": "^36.5.0"
+        "electron": "^36.5.0",
+        "electron-log": "^5.4.1"
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.6.3",
@@ -5011,6 +5012,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"
+      }
+    },
+    "node_modules/electron-log": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/electron-log/-/electron-log-5.4.1.tgz",
+      "integrity": "sha512-QvisA18Z++8E3Th0zmhUelys9dEv7aIeXJlbFw3UrxCc8H9qSRW0j8/ooTef/EtHui8tVmbKSL+EIQzP9GoRLg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/electron-publish": {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "postinstall": "cd app && npm install"
   },
   "dependencies": {
-    "electron": "^36.5.0"
+    "electron": "^36.5.0",
+    "electron-log": "^5.4.1"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.6.3",

--- a/packages/main/db.ts
+++ b/packages/main/db.ts
@@ -1,4 +1,5 @@
 import { Pool } from 'pg';
+import log from 'electron-log';
 
 const pool: Pool = new Pool({
   connectionString: 'postgres://user:password@localhost:5432/VAStats',
@@ -9,7 +10,7 @@ export async function getPilots(): Promise<any[]> {
     const { rows } = await pool.query('SELECT * FROM pilots');
     return rows;
   } catch (error) {
-    console.error(error);
+    log.error(error);
     throw error;
   }
 }
@@ -19,7 +20,7 @@ export async function getAircraft(): Promise<any[]> {
     const { rows } = await pool.query('SELECT * FROM aircraft');
     return rows;
   } catch (error) {
-    console.error(error);
+    log.error(error);
     throw error;
   }
 }
@@ -29,7 +30,7 @@ export async function getFlights(): Promise<any[]> {
     const { rows } = await pool.query('SELECT * FROM flights');
     return rows;
   } catch (error) {
-    console.error(error);
+    log.error(error);
     throw error;
   }
 }
@@ -39,7 +40,7 @@ export async function getEvents(): Promise<any[]> {
     const { rows } = await pool.query('SELECT * FROM events');
     return rows;
   } catch (error) {
-    console.error(error);
+    log.error(error);
     throw error;
   }
 }
@@ -49,7 +50,7 @@ export async function getNotifications(): Promise<any[]> {
     const { rows } = await pool.query('SELECT * FROM notifications');
     return rows;
   } catch (error) {
-    console.error(error);
+    log.error(error);
     throw error;
   }
 }
@@ -59,7 +60,7 @@ export async function getAcarsLogs(flightId: number): Promise<any[]> {
     const { rows } = await pool.query('SELECT * FROM acars_logs WHERE flight_id = $1', [flightId]);
     return rows;
   } catch (error) {
-    console.error(error);
+    log.error(error);
     throw error;
   }
 }

--- a/packages/main/main.ts
+++ b/packages/main/main.ts
@@ -2,6 +2,9 @@ import { app, BrowserWindow, ipcMain, shell } from 'electron';
 import path from 'path';
 import fs from 'fs';
 import * as db from './db';
+import log from 'electron-log';
+
+log.initialize();
 
 const isDev = !app.isPackaged;
 
@@ -41,12 +44,59 @@ function createWindow(): void {
     win.loadFile(path.join(__dirname, '../app/dist/index.html'));
   }
 
-  ipcMain.handle('db:getPilots', () => db.getPilots());
-  ipcMain.handle('db:getAircraft', () => db.getAircraft());
-  ipcMain.handle('db:getFlights', () => db.getFlights());
-  ipcMain.handle('db:getEvents', () => db.getEvents());
-  ipcMain.handle('db:getNotifications', () => db.getNotifications());
-  ipcMain.handle('db:getAcarsLogs', (_evt, flightId: number) => db.getAcarsLogs(flightId));
+  ipcMain.handle('db:getPilots', async () => {
+    try {
+      return await db.getPilots();
+    } catch (error) {
+      log.error('db:getPilots', error);
+      throw error;
+    }
+  });
+
+  ipcMain.handle('db:getAircraft', async () => {
+    try {
+      return await db.getAircraft();
+    } catch (error) {
+      log.error('db:getAircraft', error);
+      throw error;
+    }
+  });
+
+  ipcMain.handle('db:getFlights', async () => {
+    try {
+      return await db.getFlights();
+    } catch (error) {
+      log.error('db:getFlights', error);
+      throw error;
+    }
+  });
+
+  ipcMain.handle('db:getEvents', async () => {
+    try {
+      return await db.getEvents();
+    } catch (error) {
+      log.error('db:getEvents', error);
+      throw error;
+    }
+  });
+
+  ipcMain.handle('db:getNotifications', async () => {
+    try {
+      return await db.getNotifications();
+    } catch (error) {
+      log.error('db:getNotifications', error);
+      throw error;
+    }
+  });
+
+  ipcMain.handle('db:getAcarsLogs', async (_evt, flightId: number) => {
+    try {
+      return await db.getAcarsLogs(flightId);
+    } catch (error) {
+      log.error('db:getAcarsLogs', error);
+      throw error;
+    }
+  });
 }
 
 app.whenReady().then(createWindow);


### PR DESCRIPTION
## Summary
- add electron-log dependency
- initialize logger in main process and log IPC errors
- replace console error calls in database layer with logger

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685b417a5e2c83228a8bce053d6c1364