### PR TITLE
Improve DB configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+DATABASE_URL=postgres://user:password@localhost:5432/VAStats

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ app/dist
 .DS_Store
 dist
 out
+.env

--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ The root `npm install` triggers a `postinstall` step that installs the React
 dependencies in `app`. If you skip that step, run `npm install` inside
 `app` manually.
 
+### Database Configuration
+
+The Electron process reads a `DATABASE_URL` environment variable to connect to
+PostgreSQL. You can create a `.env` file in the project root to override the
+default connection string:
+
+```bash
+DATABASE_URL=postgres://user:password@localhost:5432/VAStats
+```
+
+Any values in `.env` will be loaded automatically when the app starts.
+
 ## Building
 
 Create a packaged build with:

--- a/electron/db.js
+++ b/electron/db.js
@@ -11,6 +11,8 @@ exports.getNotifications = getNotifications;
 exports.getAcarsLogs = getAcarsLogs;
 const pg_1 = require("pg");
 const electron_log_1 = __importDefault(require("electron-log"));
+const dotenv_1 = __importDefault(require("dotenv"));
+dotenv_1.default.config();
 const connectionString = process.env.DATABASE_URL ||
     'postgres://user:password@localhost:5432/VAStats';
 const pool = new pg_1.Pool({

--- a/electron/main.js
+++ b/electron/main.js
@@ -40,6 +40,8 @@ const electron_1 = require("electron");
 const path_1 = __importDefault(require("path"));
 const fs_1 = __importDefault(require("fs"));
 const db = __importStar(require("./db"));
+const electron_log_1 = __importDefault(require("electron-log"));
+electron_log_1.default.initialize();
 const isDev = !electron_1.app.isPackaged;
 const stateFile = path_1.default.join(electron_1.app.getPath('userData'), 'state.json');
 electron_1.ipcMain.on('save-state', (_, state) => {
@@ -74,12 +76,60 @@ function createWindow() {
     else {
         win.loadFile(path_1.default.join(__dirname, '../app/dist/index.html'));
     }
-    electron_1.ipcMain.handle('db:getPilots', () => db.getPilots());
-    electron_1.ipcMain.handle('db:getAircraft', () => db.getAircraft());
-    electron_1.ipcMain.handle('db:getFlights', () => db.getFlights());
-    electron_1.ipcMain.handle('db:getEvents', () => db.getEvents());
-    electron_1.ipcMain.handle('db:getNotifications', () => db.getNotifications());
-    electron_1.ipcMain.handle('db:getAcarsLogs', (_evt, flightId) => db.getAcarsLogs(flightId));
+    electron_1.ipcMain.handle('db:getPilots', async () => {
+        try {
+            return await db.getPilots();
+        }
+        catch (error) {
+            electron_log_1.default.error('db:getPilots', error);
+            throw error;
+        }
+    });
+    electron_1.ipcMain.handle('db:getAircraft', async () => {
+        try {
+            return await db.getAircraft();
+        }
+        catch (error) {
+            electron_log_1.default.error('db:getAircraft', error);
+            throw error;
+        }
+    });
+    electron_1.ipcMain.handle('db:getFlights', async () => {
+        try {
+            return await db.getFlights();
+        }
+        catch (error) {
+            electron_log_1.default.error('db:getFlights', error);
+            throw error;
+        }
+    });
+    electron_1.ipcMain.handle('db:getEvents', async () => {
+        try {
+            return await db.getEvents();
+        }
+        catch (error) {
+            electron_log_1.default.error('db:getEvents', error);
+            throw error;
+        }
+    });
+    electron_1.ipcMain.handle('db:getNotifications', async () => {
+        try {
+            return await db.getNotifications();
+        }
+        catch (error) {
+            electron_log_1.default.error('db:getNotifications', error);
+            throw error;
+        }
+    });
+    electron_1.ipcMain.handle('db:getAcarsLogs', async (_evt, flightId) => {
+        try {
+            return await db.getAcarsLogs(flightId);
+        }
+        catch (error) {
+            electron_log_1.default.error('db:getAcarsLogs', error);
+            throw error;
+        }
+    });
 }
 electron_1.app.whenReady().then(createWindow);
 electron_1.app.on('activate', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "hasInstallScript": true,
       "dependencies": {
+        "dotenv": "^16.5.0",
         "electron": "^36.5.0",
         "electron-log": "^5.4.1",
         "pg": "^8.16.2"
@@ -4858,7 +4859,6 @@
       "version": "16.5.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
       "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
-      "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "postinstall": "cd app && npm install"
   },
   "dependencies": {
+    "dotenv": "^16.5.0",
     "electron": "^36.5.0",
     "electron-log": "^5.4.1",
     "pg": "^8.16.2"

--- a/packages/main/db.ts
+++ b/packages/main/db.ts
@@ -1,5 +1,8 @@
 import { Pool } from 'pg';
 import log from 'electron-log';
+import dotenv from 'dotenv';
+
+dotenv.config();
 
 const connectionString =
   process.env.DATABASE_URL ||


### PR DESCRIPTION
## Summary
- load environment variables with dotenv
- include sample `.env` file
- document DB configuration in README

## Testing
- `npm run build:main`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685b49b3c6948322b4079822c6be6d1d